### PR TITLE
Add SERVER_TICK_END packet support for RSProxy live logging

### DIFF
--- a/game-server/src/main/kotlin/org/alter/game/message/ServerTickEndHandler.kt
+++ b/game-server/src/main/kotlin/org/alter/game/message/ServerTickEndHandler.kt
@@ -1,0 +1,23 @@
+package org.alter.game.message
+
+import net.rsprot.protocol.game.outgoing.misc.client.ServerTickEnd
+
+/**
+ * A message handler for ServerTickEnd which signals the end of a server tick cycle.
+ * This is used by RSProxy to properly timestamp packets for live logging.
+ */
+class ServerTickEndHandler {
+    companion object {
+        /**
+         * Send a server tick end message to all connected players.
+         * This should be called at the end of each game tick cycle.
+         */
+        fun sendToAll(world: org.alter.game.model.World) {
+            world.players.forEach { player ->
+                if (player.initiated) {
+                    player.write(ServerTickEnd)
+                }
+            }
+        }
+    }
+}

--- a/game-server/src/main/kotlin/org/alter/game/service/GameService.kt
+++ b/game-server/src/main/kotlin/org/alter/game/service/GameService.kt
@@ -9,6 +9,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.asCoroutineDispatcher
+import org.alter.game.message.ServerTickEndHandler
 import org.alter.game.model.World
 import org.alter.game.task.*
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -190,6 +191,8 @@ class GameService : Service {
             taskTimes[task.javaClass] = System.currentTimeMillis() - taskStart
         }
         world.cycle()
+
+        ServerTickEndHandler.sendToAll(world)
 
         /*
          * Calculate the time, in milliseconds, it took for this cycle to complete


### PR DESCRIPTION
## Summary
- Add `ServerTickEndHandler` to send `SERVER_TICK_END` packets to all players at the end of each game tick cycle
- This enables RSProxy to properly timestamp packets for live logging in the RuneLite client

## Changes
- **New file**: `game-server/src/main/kotlin/org/alter/game/message/ServerTickEndHandler.kt`
- **Modified**: `game-server/src/main/kotlin/org/alter/game/service/GameService.kt`