### PR TITLE
Route social features through OpenRune-Central

### DIFF
--- a/api/net/build.gradle.kts
+++ b/api/net/build.gradle.kts
@@ -42,4 +42,6 @@ dependencies {
     implementation(projects.engine.routefinder)
     implementation(projects.engine.plugin)
     implementation(projects.server.services)
+    implementation(projects.api.social)
+    implementation(projects.api.dbGateway)
 }

--- a/api/net/src/main/kotlin/org/rsmod/api/net/central/CentralSocialClientPackets.kt
+++ b/api/net/src/main/kotlin/org/rsmod/api/net/central/CentralSocialClientPackets.kt
@@ -1,0 +1,54 @@
+package org.rsmod.api.net.central
+
+import net.rsprot.protocol.game.outgoing.misc.player.ChatFilterSettingsPrivateChat
+import net.rsprot.protocol.game.outgoing.social.FriendListLoaded
+import net.rsprot.protocol.game.outgoing.social.UpdateFriendList
+import net.rsprot.protocol.game.outgoing.social.UpdateIgnoreList
+import org.rsmod.game.entity.Player
+
+fun Player.writeCentralSocialSnapshot(snapshot: WorldLinkFrameSpecs.CentralSocialSnapshot) {
+    client.write(FriendListLoaded)
+
+    client.write(ChatFilterSettingsPrivateChat(snapshot.privateChat))
+
+    val friendEntries =
+        snapshot.friends.map { friend ->
+            if (friend.worldId > 0) {
+                UpdateFriendList.OnlineFriend(
+                    added = false,
+                    name = friend.displayName,
+                    previousName = friend.previousDisplayName,
+                    worldId = friend.worldId,
+                    rank = 0,
+                    properties = 0,
+                    notes = "",
+                    worldName = "OpenRune",
+                    platform = 8,
+                    worldFlags = 0,
+                )
+            } else {
+                UpdateFriendList.OfflineFriend(
+                    added = false,
+                    name = friend.displayName,
+                    previousName = friend.previousDisplayName,
+                    rank = 0,
+                    properties = 0,
+                    notes = "",
+                )
+            }
+        }
+
+    client.write(UpdateFriendList(friendEntries))
+
+    val ignoreEntries =
+        snapshot.ignores.map { ignore ->
+            UpdateIgnoreList.AddedIgnoredEntry(
+                name = ignore.displayName,
+                previousName = ignore.previousDisplayName,
+                note = "",
+                added = false,
+            )
+        }
+
+    client.write(UpdateIgnoreList(ignoreEntries))
+}

--- a/api/net/src/main/kotlin/org/rsmod/api/net/central/CentralSocialService.kt
+++ b/api/net/src/main/kotlin/org/rsmod/api/net/central/CentralSocialService.kt
@@ -1,0 +1,190 @@
+package org.rsmod.api.net.central
+
+import jakarta.inject.Inject
+import org.rsmod.api.db.gateway.model.GameDbResult
+
+class CentralSocialService
+@Inject
+constructor(
+    private val central: OpenRuneCentralWorldLink,
+) {
+    fun addFriend(
+        sessionToken: ByteArray,
+        characterId: Int,
+        name: String,
+    ): GameDbResult<CentralSocialResult> {
+        val cleaned = name.trim()
+        if (cleaned.isBlank()) {
+            return GameDbResult.Ok(CentralSocialResult.Ignored)
+        }
+
+        if (characterId <= 0) {
+            return GameDbResult.Ok(
+                CentralSocialResult.Failed("Social is not available right now.")
+            )
+        }
+
+        return GameDbResult.Ok(
+            central.addFriend(
+                sessionToken = sessionToken,
+                characterId = characterId,
+                targetName = cleaned,
+            )
+        )
+    }
+
+    fun deleteFriend(
+        sessionToken: ByteArray,
+        characterId: Int,
+        name: String,
+    ): GameDbResult<CentralSocialResult> {
+        val cleaned = name.trim()
+        if (cleaned.isBlank()) {
+            return GameDbResult.Ok(CentralSocialResult.Ignored)
+        }
+
+        if (characterId <= 0) {
+            return GameDbResult.Ok(
+                CentralSocialResult.Failed("Social is not available right now.")
+            )
+        }
+
+        return GameDbResult.Ok(
+            central.deleteFriend(
+                sessionToken = sessionToken,
+                characterId = characterId,
+                targetName = cleaned,
+            )
+        )
+    }
+
+    fun socialSnapshot(
+        sessionToken: ByteArray,
+        characterId: Int,
+    ): GameDbResult<OpenRuneCentralWorldLink.CentralSocialSnapshotResult> {
+        if (characterId <= 0) {
+            return GameDbResult.Ok(
+                OpenRuneCentralWorldLink.CentralSocialSnapshotResult.Failed("Social is not available right now.")
+            )
+        }
+
+        return GameDbResult.Ok(
+            central.socialSnapshot(
+                sessionToken = sessionToken,
+                characterId = characterId,
+            )
+        )
+    }
+
+    fun addIgnore(
+        sessionToken: ByteArray,
+        characterId: Int,
+        name: String,
+    ): GameDbResult<CentralSocialResult> {
+        val cleaned = name.trim()
+        if (cleaned.isBlank()) {
+            return GameDbResult.Ok(CentralSocialResult.Ignored)
+        }
+
+        if (characterId <= 0) {
+            return GameDbResult.Ok(
+                CentralSocialResult.Failed("Social is not available right now.")
+            )
+        }
+
+        return GameDbResult.Ok(
+            central.addIgnore(
+                sessionToken = sessionToken,
+                characterId = characterId,
+                targetName = cleaned,
+            )
+        )
+    }
+
+    fun deleteIgnore(
+        sessionToken: ByteArray,
+        characterId: Int,
+        name: String,
+    ): GameDbResult<CentralSocialResult> {
+        val cleaned = name.trim()
+        if (cleaned.isBlank()) {
+            return GameDbResult.Ok(CentralSocialResult.Ignored)
+        }
+
+        if (characterId <= 0) {
+            return GameDbResult.Ok(
+                CentralSocialResult.Failed("Social is not available right now.")
+            )
+        }
+
+        return GameDbResult.Ok(
+            central.deleteIgnore(
+                sessionToken = sessionToken,
+                characterId = characterId,
+                targetName = cleaned,
+            )
+        )
+    }
+
+    fun sendPrivateMessage(
+        sessionToken: ByteArray,
+        fromCharacterId: Int,
+        targetName: String,
+        senderDisplayName: String,
+        senderCrown: Int,
+        message: String,
+    ): GameDbResult<CentralSocialResult> {
+        val cleanedTarget = targetName.trim()
+        val cleanedMessage = message.trim()
+
+        if (cleanedTarget.isBlank() || cleanedMessage.isBlank()) {
+            return GameDbResult.Ok(CentralSocialResult.Ignored)
+        }
+
+        if (fromCharacterId <= 0) {
+            return GameDbResult.Ok(
+                CentralSocialResult.Failed("Private messaging is not available right now.")
+            )
+        }
+
+        return GameDbResult.Ok(
+            central.sendPrivateMessage(
+                sessionToken = sessionToken,
+                fromCharacterId = fromCharacterId,
+                targetName = cleanedTarget,
+                senderDisplayName = senderDisplayName,
+                senderCrown = senderCrown,
+                message = cleanedMessage,
+            )
+        )
+    }
+
+    fun setPrivateChatFilter(
+        sessionToken: ByteArray,
+        characterId: Int,
+        privateChatFilter: Int,
+    ): GameDbResult<CentralSocialResult> {
+        if (characterId <= 0) {
+            return GameDbResult.Ok(
+                CentralSocialResult.Failed("Social settings are not available right now.")
+            )
+        }
+
+        return GameDbResult.Ok(
+            central.setPrivateChatFilter(
+                sessionToken = sessionToken,
+                characterId = characterId,
+                privateChatFilter = privateChatFilter,
+            )
+        )
+    }
+}
+
+    sealed class CentralSocialResult {
+        data object Ok : CentralSocialResult()
+        data object Ignored : CentralSocialResult()
+
+        data class Failed(
+            val message: String,
+    ) : CentralSocialResult()
+}

--- a/api/net/src/main/kotlin/org/rsmod/api/net/central/CentralSocialService.kt
+++ b/api/net/src/main/kotlin/org/rsmod/api/net/central/CentralSocialService.kt
@@ -2,6 +2,7 @@ package org.rsmod.api.net.central
 
 import jakarta.inject.Inject
 import org.rsmod.api.db.gateway.model.GameDbResult
+import org.rsmod.api.net.central.WorldLinkFrameSpecs.PRIVATE_MESSAGE_MAX_CHARS
 
 class CentralSocialService
 @Inject
@@ -135,7 +136,7 @@ constructor(
         message: String,
     ): GameDbResult<CentralSocialResult> {
         val cleanedTarget = targetName.trim()
-        val cleanedMessage = message.trim()
+        val cleanedMessage = message.trim().take(PRIVATE_MESSAGE_MAX_CHARS)
 
         if (cleanedTarget.isBlank() || cleanedMessage.isBlank()) {
             return GameDbResult.Ok(CentralSocialResult.Ignored)
@@ -180,11 +181,11 @@ constructor(
     }
 }
 
-    sealed class CentralSocialResult {
-        data object Ok : CentralSocialResult()
-        data object Ignored : CentralSocialResult()
+sealed class CentralSocialResult {
+    data object Ok : CentralSocialResult()
+    data object Ignored : CentralSocialResult()
 
-        data class Failed(
-            val message: String,
+    data class Failed(
+        val message: String,
     ) : CentralSocialResult()
 }

--- a/api/net/src/main/kotlin/org/rsmod/api/net/central/OpenRuneCentralWorldLink.kt
+++ b/api/net/src/main/kotlin/org/rsmod/api/net/central/OpenRuneCentralWorldLink.kt
@@ -6,6 +6,7 @@ import java.net.InetSocketAddress
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.ConcurrentLinkedQueue
+import net.rsprot.protocol.game.outgoing.social.MessagePrivate
 import net.rsprot.protocol.loginprot.outgoing.LoginResponse
 import org.rsmod.api.player.output.ChatType
 import org.rsmod.api.player.output.MiscOutput
@@ -15,6 +16,7 @@ import org.rsmod.api.net.central.netty.WorldLinkNettyBlockingSession
 import org.rsmod.api.registry.player.PlayerRegistry
 import org.rsmod.api.server.config.OpenRuneCentralGameConfig
 import org.rsmod.api.server.config.ServerConfig
+import org.rsmod.api.social.writeFriendPresenceDelta
 import org.rsmod.game.GameUpdate
 import org.rsmod.game.GameUpdate.Companion.isUpdating
 
@@ -43,6 +45,12 @@ constructor(
 
     private val pendingCentralDisplayNameSyncs =
         ConcurrentLinkedQueue<WorldLinkFrameSpecs.ServerDisplayNameSyncPayload>()
+
+    private val pendingCentralPrivateMessages =
+        ConcurrentLinkedQueue<WorldLinkFrameSpecs.ServerPrivateMessagePayload>()
+
+    private val pendingCentralFriendPresence =
+        ConcurrentLinkedQueue<WorldLinkFrameSpecs.ServerFriendPresencePayload>()
 
     @Volatile
     private var inboundWatchStop: Boolean = true
@@ -169,8 +177,219 @@ constructor(
         }
         while (true) {
             val d = pendingCentralDisplayNameSyncs.poll() ?: break
-            playerRegistry.applyCentralDisplayNameSync(d.accountId, d.characterId, d.newDisplayName, d.priorDisplayName)
+            playerRegistry.applyCentralDisplayNameSync(
+                d.accountId,
+                d.characterId,
+                d.newDisplayName,
+                d.priorDisplayName
+            )
         }
+        while (true) {
+            val presence = pendingCentralFriendPresence.poll() ?: break
+
+            playerRegistry.forEachOnline { player ->
+                if (player.characterId != presence.ownerCharacterId) {
+                    return@forEachOnline
+                }
+
+                player.writeFriendPresenceDelta(
+                    name = presence.friendDisplayName,
+                    previousName = presence.friendPreviousDisplayName,
+                    worldId = presence.friendWorldId,
+                )
+            }
+        }
+
+        while (true) {
+            val pm = pendingCentralPrivateMessages.poll() ?: break
+            var delivered = false
+
+            playerRegistry.forEachOnline { player ->
+                if (player.characterId != pm.toCharacterId) {
+                    return@forEachOnline
+                }
+
+                player.client.write(
+                    MessagePrivate(
+                        sender = pm.senderDisplayName,
+                        worldId = pm.senderWorldId,
+                        worldMessageCounter = nextCentralPrivateMessageCounter(),
+                        chatCrownType = pm.senderCrown,
+                        message = pm.message,
+                    )
+                )
+
+                delivered = true
+            }
+
+            if (!delivered) {
+                logger.debug {
+                    "Central PM target was not online locally: toCharacterId=${pm.toCharacterId}"
+                }
+            }
+        }
+    }
+
+    public fun addFriend(
+        sessionToken: ByteArray,
+        characterId: Int,
+        targetName: String,
+    ): CentralSocialResult {
+        return sendSocialRequest(
+            frame = WorldLinkPackets.friendAdd(sessionToken, characterId, targetName),
+            fallbackMessage = "Unable to add player right now.",
+        )
+    }
+
+    public fun deleteFriend(
+        sessionToken: ByteArray,
+        characterId: Int,
+        targetName: String,
+    ): CentralSocialResult {
+        return sendSocialRequest(
+            frame = WorldLinkPackets.friendDelete(sessionToken, characterId, targetName),
+            fallbackMessage = "Unable to delete friend right now.",
+        )
+    }
+
+    public fun addIgnore(
+        sessionToken: ByteArray,
+        characterId: Int,
+        targetName: String,
+    ): CentralSocialResult {
+        return sendSocialRequest(
+            frame = WorldLinkPackets.ignoreAdd(sessionToken, characterId, targetName),
+            fallbackMessage = "Unable to ignore player right now.",
+        )
+    }
+
+    public fun deleteIgnore(
+        sessionToken: ByteArray,
+        characterId: Int,
+        targetName: String,
+    ): CentralSocialResult {
+        return sendSocialRequest(
+            frame = WorldLinkPackets.ignoreDelete(sessionToken, characterId, targetName),
+            fallbackMessage = "Unable to delete ignore right now.",
+        )
+    }
+
+    public fun sendPrivateMessage(
+        sessionToken: ByteArray,
+        fromCharacterId: Int,
+        targetName: String,
+        senderDisplayName: String,
+        senderCrown: Int,
+        message: String,
+    ): CentralSocialResult {
+        return sendSocialRequest(
+            frame =
+                WorldLinkPackets.privateMessageRelay(
+                    sessionToken = sessionToken,
+                    fromCharacterId = fromCharacterId,
+                    targetName = targetName,
+                    senderDisplayName = senderDisplayName,
+                    senderCrown = senderCrown,
+                    message = message,
+                ),
+            fallbackMessage = "Unable to send private message right now.",
+        )
+    }
+
+    public fun setPrivateChatFilter(
+        sessionToken: ByteArray,
+        characterId: Int,
+        privateChatFilter: Int,
+    ): CentralSocialResult {
+        return sendSocialRequest(
+            frame =
+                WorldLinkPackets.privateChatFilter(
+                    sessionToken = sessionToken,
+                    characterId = characterId,
+                    privateChatFilter = privateChatFilter,
+                ),
+            fallbackMessage = "Unable to update private chat filter right now.",
+        )
+    }
+
+    public sealed class CentralSocialSnapshotResult {
+        public data class Ok(
+            val snapshot: WorldLinkFrameSpecs.CentralSocialSnapshot,
+        ) : CentralSocialSnapshotResult()
+
+        public data class Failed(
+            val message: String,
+        ) : CentralSocialSnapshotResult()
+    }
+
+    public fun socialSnapshot(
+        sessionToken: ByteArray,
+        characterId: Int,
+    ): CentralSocialSnapshotResult {
+        val cfg = settings ?: return CentralSocialSnapshotResult.Failed("Central is not enabled.")
+        val frame = WorldLinkPackets.socialSync(sessionToken, characterId)
+
+        repeat(MAX_AUTH_ATTEMPTS) { attempt ->
+            try {
+                validateGameToCentralFrameOrThrow(frame)
+
+                val session =
+                    WorldLinkNettyBlockingClient.connect(
+                        InetSocketAddress(cfg.host, cfg.port),
+                        readIdleSeconds = SOCKET_TIMEOUT_SECONDS,
+                    )
+
+                try {
+                    sendHello(session, cfg.worldKey, serverConfig.world)
+                    session.send(frame)
+
+                    val response = session.recvInbound(SOCKET_TIMEOUT_MS.toLong())
+                    val invalid = WorldLinkFrameSpecs.validateCentralToGameFrame(response)
+                    if (invalid != null) {
+                        logger.warn {
+                            "Central social sync reply failed validation: " +
+                                WorldLinkFrameSpecs.describeValidationFailure(invalid)
+                        }
+                        return CentralSocialSnapshotResult.Failed("Unable to load social list right now.")
+                    }
+
+                    return when (val op = response[0].toInt() and 0xFF) {
+                        WorldLinkFrameSpecs.OP_WORLD_SOCIAL_SYNC_OK ->
+                            CentralSocialSnapshotResult.Ok(
+                                WorldLinkFrameSpecs.decodeSocialSnapshot(response)
+                            )
+
+                        WorldLinkFrameSpecs.OP_WORLD_SOCIAL_SYNC_FAIL -> {
+                            val reason = if (response.size > 1) response[1].toInt() and 0xFF else 0
+                            CentralSocialSnapshotResult.Failed(socialFailureMessage(reason))
+                        }
+
+                        else -> {
+                            logger.warn {
+                                "Unexpected Central social sync reply opcode 0x${op.toString(16)}"
+                            }
+                            CentralSocialSnapshotResult.Failed("Unable to load social list right now.")
+                        }
+                    }
+                } finally {
+                    session.close()
+                }
+            } catch (e: Exception) {
+                if (!isRetryableCentralNetworkFailure(e) || attempt + 1 >= MAX_AUTH_ATTEMPTS) {
+                    logger.warn(e) { "Central social sync request failed." }
+                    return CentralSocialSnapshotResult.Failed("Unable to load social list right now.")
+                }
+
+                try {
+                    Thread.sleep(RETRY_BASE_MS * (attempt + 1))
+                } catch (_: InterruptedException) {
+                    Thread.currentThread().interrupt()
+                    return CentralSocialSnapshotResult.Failed("Unable to load social list right now.")
+                }
+            }
+        }
+
+        return CentralSocialSnapshotResult.Failed("Unable to load social list right now.")
     }
 
     public fun notifyLogout(sessionToken: ByteArray) {
@@ -202,6 +421,85 @@ constructor(
             }
         }
     }
+
+    private fun sendSocialRequest(
+        frame: ByteArray,
+        fallbackMessage: String,
+    ): CentralSocialResult {
+        val cfg = settings ?: return CentralSocialResult.Failed("Central is not enabled.")
+
+        repeat(MAX_AUTH_ATTEMPTS) { attempt ->
+            try {
+                validateGameToCentralFrameOrThrow(frame)
+
+                val session =
+                    WorldLinkNettyBlockingClient.connect(
+                        InetSocketAddress(cfg.host, cfg.port),
+                        readIdleSeconds = SOCKET_TIMEOUT_SECONDS,
+                    )
+
+                try {
+                    sendHello(session, cfg.worldKey, serverConfig.world)
+                    session.send(frame)
+
+                    val response = session.recvInbound(SOCKET_TIMEOUT_MS.toLong())
+                    val invalid = WorldLinkFrameSpecs.validateCentralToGameFrame(response)
+                    if (invalid != null) {
+                        logger.warn {
+                            "Central social reply failed validation: " +
+                                WorldLinkFrameSpecs.describeValidationFailure(invalid)
+                        }
+                        return CentralSocialResult.Failed(fallbackMessage)
+                    }
+
+                    return when (val op = response[0].toInt() and 0xFF) {
+                        WorldLinkFrameSpecs.OP_WORLD_SOCIAL_OK -> CentralSocialResult.Ok
+
+                        WorldLinkFrameSpecs.OP_WORLD_SOCIAL_FAIL -> {
+                            val reason = if (response.size > 1) response[1].toInt() and 0xFF else 0
+                            CentralSocialResult.Failed(socialFailureMessage(reason))
+                        }
+
+                        else -> {
+                            logger.warn {
+                                "Unexpected Central social reply opcode 0x${op.toString(16)}"
+                            }
+                            CentralSocialResult.Failed(fallbackMessage)
+                        }
+                    }
+                } finally {
+                    session.close()
+                }
+            } catch (e: Exception) {
+                if (!isRetryableCentralNetworkFailure(e) || attempt + 1 >= MAX_AUTH_ATTEMPTS) {
+                    logger.warn(e) { "Central social request failed." }
+                    return CentralSocialResult.Failed(fallbackMessage)
+                }
+
+                try {
+                    Thread.sleep(RETRY_BASE_MS * (attempt + 1))
+                } catch (_: InterruptedException) {
+                    Thread.currentThread().interrupt()
+                    return CentralSocialResult.Failed(fallbackMessage)
+                }
+            }
+        }
+
+        return CentralSocialResult.Failed(fallbackMessage)
+    }
+
+    private fun socialFailureMessage(reason: Int): String =
+        when (reason) {
+            1 -> "Unable to add friend - unknown player."
+            2 -> "You cannot add yourself to your own friends list."
+            3 -> "That player is already on your friend list."
+            4 -> "That player is already on your ignore list."
+            5 -> "That player is not accepting private messages."
+            6 -> "That player is currently offline."
+            7 -> "Your social list is full."
+            8 -> "You are not allowed to do that right now."
+            else -> "Unable to complete social request right now."
+        }
 
     private fun openCentralAuthSession(
         cfg: CentralSettings,
@@ -407,6 +705,8 @@ constructor(
             else -> LoginResponse.InvalidUsernameOrPassword
         }
 
+    // Long-lived Central push subscription. Short-lived request
+    // sessions must not be used for PM/presence delivery.
     private fun runInboundWatchLoop(cfg: CentralSettings) {
         while (!inboundWatchStop && !Thread.currentThread().isInterrupted) {
             var session: WorldLinkNettyBlockingSession? = null
@@ -438,10 +738,11 @@ constructor(
                         onReboot = { pendingCentralReboots.add(it) },
                         onBroadcast = { pendingCentralBroadcasts.add(it) },
                         onDisplayNameSync = { pendingCentralDisplayNameSyncs.add(it) },
+                        onPrivateMessage = { pendingCentralPrivateMessages.add(it) },
+                        onFriendPresence = { pendingCentralFriendPresence.add(it) },
                         onOther = { op ->
                             logger.debug {
-                                "Ignoring Central world-link opcode 0x${op.toString(16)} on push channel " +
-                                    "(not a server push)"
+                                "Ignoring Central world-link opcode 0x${op.toString(16)} on push channel (not a server push)"
                             }
                         },
                     )
@@ -522,6 +823,18 @@ constructor(
         private const val INBOUND_POLL_MS: Long = 1_000L
 
         private const val GAME_CYCLE_MS: Long = 600L
+
+        private var centralPrivateMessageCounter: Int = 1
+
+        private fun nextCentralPrivateMessageCounter(): Int {
+            centralPrivateMessageCounter = (centralPrivateMessageCounter + 1) and 0xFFFFFF
+
+            if (centralPrivateMessageCounter <= 0) {
+                centralPrivateMessageCounter = 1
+            }
+
+            return centralPrivateMessageCounter
+        }
     }
 }
 

--- a/api/net/src/main/kotlin/org/rsmod/api/net/central/OpenRuneCentralWorldLink.kt
+++ b/api/net/src/main/kotlin/org/rsmod/api/net/central/OpenRuneCentralWorldLink.kt
@@ -90,6 +90,57 @@ constructor(
         return CentralAuthResult.Denied(LoginResponse.LoginServerOffline)
     }
 
+    public fun heartbeat(sessionToken: ByteArray): Boolean {
+        val cfg = settings ?: return false
+        val frame = WorldLinkPackets.heartbeat(sessionToken)
+
+        repeat(MAX_AUTH_ATTEMPTS) { attempt ->
+            try {
+                validateGameToCentralFrameOrThrow(frame)
+
+                val session =
+                    WorldLinkNettyBlockingClient.connect(
+                        InetSocketAddress(cfg.host, cfg.port),
+                        readIdleSeconds = SOCKET_TIMEOUT_SECONDS,
+                    )
+
+                try {
+                    sendHello(session, cfg.worldKey, serverConfig.world)
+                    session.send(frame)
+
+                    val response = session.recvInbound(SOCKET_TIMEOUT_MS.toLong())
+                    val invalid = WorldLinkFrameSpecs.validateCentralToGameFrame(response)
+                    if (invalid != null) {
+                        logger.debug {
+                            "Central heartbeat reply failed validation: " +
+                                WorldLinkFrameSpecs.describeValidationFailure(invalid)
+                        }
+                        return false
+                    }
+
+                    val op = response[0].toInt() and 0xFF
+                    return op == WorldLinkFrameSpecs.OP_HEARTBEAT_ACK
+                } finally {
+                    session.close()
+                }
+            } catch (e: Exception) {
+                if (!isRetryableCentralNetworkFailure(e) || attempt + 1 >= MAX_AUTH_ATTEMPTS) {
+                    logger.debug(e) { "Central heartbeat failed." }
+                    return false
+                }
+
+                try {
+                    Thread.sleep(RETRY_BASE_MS * (attempt + 1))
+                } catch (_: InterruptedException) {
+                    Thread.currentThread().interrupt()
+                    return false
+                }
+            }
+        }
+
+        return false
+    }
+
     public fun startInboundWatch() {
         val cfg = settings ?: return
         if (!inboundWatchStop) {

--- a/api/net/src/main/kotlin/org/rsmod/api/net/central/WorldLinkFrameSpecs.kt
+++ b/api/net/src/main/kotlin/org/rsmod/api/net/central/WorldLinkFrameSpecs.kt
@@ -69,6 +69,7 @@ public object WorldLinkFrameSpecs {
     public const val OP_PUSH_SUBSCRIBE: Int = 0x13
     public const val OP_PUSH_SUBSCRIBE_ACK: Int = 0x14
     public const val OP_HEARTBEAT: Int = 0x30
+    public const val OP_HEARTBEAT_ACK: Int = 0x31
     public const val OP_LOGOUT: Int = 0x40
     public const val OP_LOGOUT_ACK: Int = 0x41
 
@@ -124,6 +125,7 @@ public object WorldLinkFrameSpecs {
             "login_fail_trailing" -> "LOGIN_FAIL has unexpected trailing bytes after the script lines"
             "login_ok_size" -> "LOGIN_OK body length is outside the allowed range for token + account id + rights"
             "logout_ack_size" -> "LOGOUT_ACK must have no body after the opcode"
+            "heartbeat_ack_size" -> "HEARTBEAT_ACK must have no body after the opcode"
             "push_subscribe_ack_size" -> "PUSH_SUBSCRIBE_ACK must have no body after the opcode"
             "server_revoke_login_size" -> "SERVER_REVOKE_LOGIN body must be exactly 12 bytes (account id + character id)"
             "server_mute_update_size" -> "SERVER_MUTE_UPDATE body must be exactly 20 bytes"
@@ -304,6 +306,13 @@ public object WorldLinkFrameSpecs {
             OP_WORLD_SOCIAL_SYNC_FAIL ->
                 if (bodyLen != 1) {
                     "pm_relay_fail_size"
+                } else {
+                    null
+                }
+
+            OP_HEARTBEAT_ACK ->
+                if (bodyLen != 0) {
+                    "heartbeat_ack_size"
                 } else {
                     null
                 }

--- a/api/net/src/main/kotlin/org/rsmod/api/net/central/WorldLinkFrameSpecs.kt
+++ b/api/net/src/main/kotlin/org/rsmod/api/net/central/WorldLinkFrameSpecs.kt
@@ -17,6 +17,39 @@ public object WorldLinkFrameSpecs {
 
     public const val PM_RELAY_MESSAGE_MAX_UTF8: Int = PRIVATE_MESSAGE_MAX_CHARS * 4
 
+    public const val SOCIAL_NAME_MAX_UTF8: Int = 96
+
+    public const val OP_WORLD_PM_RELAY: Int = 0x60
+    public const val OP_WORLD_FRIEND_ADD: Int = 0x61
+    public const val OP_WORLD_FRIEND_DEL: Int = 0x62
+    public const val OP_WORLD_IGNORE_ADD: Int = 0x63
+    public const val OP_WORLD_IGNORE_DEL: Int = 0x64
+    public const val OP_WORLD_CHAT_FILTERS: Int = 0x65
+
+    public const val OP_WORLD_SOCIAL_OK: Int = 0x66
+    public const val OP_WORLD_SOCIAL_FAIL: Int = 0x67
+    public const val OP_WORLD_SOCIAL_SYNC: Int = 0x69
+    public const val OP_WORLD_SOCIAL_SYNC_OK: Int = 0x6A
+    public const val OP_WORLD_SOCIAL_SYNC_FAIL: Int = 0x6B
+
+    public const val OP_SERVER_PRIVATE_MESSAGE: Int = 0x68
+    public const val OP_SERVER_FRIEND_PRESENCE: Int = 0x6C
+
+    private const val SERVER_PRIVATE_MESSAGE_MIN_BODY: Int = 4 + 4 + 4 + 1 + 2 + 0 + 2 + 0
+
+    private const val SERVER_PRIVATE_MESSAGE_MAX_BODY: Int =
+        4 + // sender world id
+            4 + // from character id
+            4 + // to character id
+            1 + // sender crown
+            2 + PM_RELAY_SENDER_DISPLAY_MAX_UTF8 +
+            2 + PM_RELAY_MESSAGE_MAX_UTF8
+
+    private const val SERVER_FRIEND_PRESENCE_MIN_BODY: Int = 4 + 4 + 4 + 2 + 0 + 2 + 0
+
+    private const val SERVER_FRIEND_PRESENCE_MAX_BODY: Int =
+        4 + 4 + 4 + 2 + SOCIAL_NAME_MAX_UTF8 + 2 + SOCIAL_NAME_MAX_UTF8
+
     public const val WORLD_KEY_MAX_BYTES: Int = 4096
 
     public const val LOGIN_FAIL_SCRIPT_LINE_MAX_UTF8_BYTES: Int = 512
@@ -63,6 +96,21 @@ public object WorldLinkFrameSpecs {
         8 + 4 + 2 + PM_RELAY_SENDER_DISPLAY_MAX_UTF8 + 2 + PM_RELAY_SENDER_DISPLAY_MAX_UTF8
 
     private const val SERVER_REBOOT_MIN_BODY: Int = 1 + 4 + 8 + 2 + 0
+
+    private const val SOCIAL_NAME_ACTION_MIN_BODY: Int = TOKEN_BODY_BYTES + 4 + 2 + 0
+    private const val SOCIAL_NAME_ACTION_MAX_BODY: Int = TOKEN_BODY_BYTES + 4 + 2 + SOCIAL_NAME_MAX_UTF8
+
+    private const val CHAT_FILTERS_BODY_BYTES: Int = TOKEN_BODY_BYTES + 4 + 3
+
+    private const val PM_RELAY_MIN_BODY: Int = TOKEN_BODY_BYTES + 4 + 1 + 2 + 0 + 2 + 0 + 2 + 0
+
+    private const val PM_RELAY_MAX_BODY: Int =
+        TOKEN_BODY_BYTES +
+            4 +
+            1 +
+            2 + SOCIAL_NAME_MAX_UTF8 +
+            2 + PM_RELAY_SENDER_DISPLAY_MAX_UTF8 +
+            2 + PM_RELAY_MESSAGE_MAX_UTF8
 
     public fun describeValidationFailure(reason: String): String =
         when (reason) {
@@ -141,6 +189,42 @@ public object WorldLinkFrameSpecs {
             OP_HEARTBEAT, OP_LOGOUT -> {
                 if (bodyLen != TOKEN_BODY_BYTES) "bad_token_frame" else null
             }
+            OP_WORLD_PM_RELAY -> {
+                if (bodyLen < PM_RELAY_MIN_BODY) {
+                    "too_short"
+                } else if (bodyLen > PM_RELAY_MAX_BODY) {
+                    "too_long"
+                } else {
+                    null
+                }
+            }
+
+            OP_WORLD_FRIEND_ADD,
+            OP_WORLD_FRIEND_DEL,
+            OP_WORLD_IGNORE_ADD,
+            OP_WORLD_IGNORE_DEL -> {
+                if (bodyLen < SOCIAL_NAME_ACTION_MIN_BODY) {
+                    "too_short"
+                } else if (bodyLen > SOCIAL_NAME_ACTION_MAX_BODY) {
+                    "too_long"
+                } else {
+                    null
+                }
+            }
+            OP_WORLD_CHAT_FILTERS -> {
+                if (bodyLen != CHAT_FILTERS_BODY_BYTES) {
+                    "too_long"
+                } else {
+                    null
+                }
+            }
+            OP_WORLD_SOCIAL_SYNC -> {
+                if (bodyLen != TOKEN_BODY_BYTES + 4) {
+                    "bad_token_frame"
+                } else {
+                    null
+                }
+            }
 
             else -> "unknown_opcode"
         }
@@ -202,11 +286,181 @@ public object WorldLinkFrameSpecs {
                 } else {
                     null
                 }
+            OP_WORLD_SOCIAL_OK ->
+                if (bodyLen != 0) {
+                    "pm_relay_ok_size"
+                } else {
+                    null
+                }
+
+            OP_WORLD_SOCIAL_FAIL ->
+                if (bodyLen != 1) {
+                    "pm_relay_fail_size"
+                } else {
+                    null
+                }
+            OP_WORLD_SOCIAL_SYNC_OK -> validateSocialSyncOkFrame(frame)
+
+            OP_WORLD_SOCIAL_SYNC_FAIL ->
+                if (bodyLen != 1) {
+                    "pm_relay_fail_size"
+                } else {
+                    null
+                }
+            OP_SERVER_FRIEND_PRESENCE -> validateServerFriendPresenceFrame(frame)
+            OP_SERVER_PRIVATE_MESSAGE -> validateServerPrivateMessageFrame(frame)
             OP_SERVER_DISPLAY_NAME_SYNC -> validateServerDisplayNameSyncFrame(frame)
             OP_SERVER_REBOOT -> validateServerRebootFrame(frame)
             OP_SERVER_BROADCAST -> validateServerBroadcastFrame(frame)
             else -> "unexpected_opcode"
         }
+    }
+
+    private fun validateServerPrivateMessageFrame(frame: ByteArray): String? {
+        val bodyLen = frame.size - 1
+
+        if (bodyLen !in SERVER_PRIVATE_MESSAGE_MIN_BODY..SERVER_PRIVATE_MESSAGE_MAX_BODY) {
+            return "server_private_message_size"
+        }
+
+        val buf = ByteBuffer.wrap(frame, 1, bodyLen)
+
+        if (buf.remaining() < 4 + 4 + 4 + 1) {
+            return "server_private_message_truncated"
+        }
+
+        buf.int // senderWorldId
+        buf.int // fromCharacterId
+        buf.int // toCharacterId
+        buf.get() // senderCrown
+
+        val displayLen =
+            readCheckedUtf8Length(buf, PM_RELAY_SENDER_DISPLAY_MAX_UTF8)
+                ?: return "server_private_message_truncated"
+
+        if (displayLen == -1) {
+            return "server_private_message_chunk_len"
+        }
+
+        if (buf.remaining() < displayLen) {
+            return "server_private_message_chunk_data"
+        }
+
+        buf.position(buf.position() + displayLen)
+
+        val messageLen =
+            readCheckedUtf8Length(buf, PM_RELAY_MESSAGE_MAX_UTF8)
+                ?: return "server_private_message_truncated"
+
+        if (messageLen == -1) {
+            return "server_private_message_chunk_len"
+        }
+
+        if (buf.remaining() < messageLen) {
+            return "server_private_message_chunk_data"
+        }
+
+        buf.position(buf.position() + messageLen)
+
+        return if (buf.remaining() != 0) {
+            "server_private_message_trailing"
+        } else {
+            null
+        }
+    }
+
+    private fun validateSocialSyncOkFrame(frame: ByteArray): String? {
+        val bodyLen = frame.size - 1
+        if (bodyLen < 3 + 2 + 2) {
+            return "too_short"
+        }
+
+        val buf = ByteBuffer.wrap(frame, 1, bodyLen)
+
+        if (buf.remaining() < 3) {
+            return "too_short"
+        }
+
+        buf.get() // public
+        buf.get() // private
+        buf.get() // trade
+
+        if (buf.remaining() < 2) {
+            return "too_short"
+        }
+
+        val friendCount = buf.short.toInt() and 0xFFFF
+        repeat(friendCount) {
+            val nameLen = readCheckedUtf8Length(buf, SOCIAL_NAME_MAX_UTF8)
+                ?: return "too_short"
+            if (nameLen == -1 || buf.remaining() < nameLen) {
+                return "too_long"
+            }
+            buf.position(buf.position() + nameLen)
+
+            val previousLen = readCheckedUtf8Length(buf, SOCIAL_NAME_MAX_UTF8)
+                ?: return "too_short"
+            if (previousLen == -1 || buf.remaining() < previousLen) {
+                return "too_long"
+            }
+            buf.position(buf.position() + previousLen)
+
+            if (buf.remaining() < 4) {
+                return "too_short"
+            }
+            buf.int
+        }
+
+        if (buf.remaining() < 2) {
+            return "too_short"
+        }
+
+        val ignoreCount = buf.short.toInt() and 0xFFFF
+        repeat(ignoreCount) {
+            val nameLen = readCheckedUtf8Length(buf, SOCIAL_NAME_MAX_UTF8)
+                ?: return "too_short"
+            if (nameLen == -1 || buf.remaining() < nameLen) {
+                return "too_long"
+            }
+            buf.position(buf.position() + nameLen)
+
+            val previousLen = readCheckedUtf8Length(buf, SOCIAL_NAME_MAX_UTF8)
+                ?: return "too_short"
+            if (previousLen == -1 || buf.remaining() < previousLen) {
+                return "too_long"
+            }
+            buf.position(buf.position() + previousLen)
+        }
+
+        return if (buf.remaining() == 0) null else "too_long"
+    }
+
+    private fun validateServerFriendPresenceFrame(frame: ByteArray): String? {
+        val bodyLen = frame.size - 1
+
+        if (bodyLen !in SERVER_FRIEND_PRESENCE_MIN_BODY..SERVER_FRIEND_PRESENCE_MAX_BODY) {
+            return "server_friend_presence_size"
+        }
+
+        val buf = ByteBuffer.wrap(frame, 1, bodyLen)
+
+        if (buf.remaining() < 4 + 4 + 4) {
+            return "server_friend_presence_truncated"
+        }
+
+        buf.int // ownerCharacterId
+        buf.int // friendCharacterId
+        buf.int // friendWorldId
+
+        if (!skipSocialUtf8(buf)) {
+            return "server_friend_presence_truncated"
+        }
+
+        if (!skipSocialUtf8(buf)) {
+            return "server_friend_presence_truncated"
+        }
+
+        return if (buf.remaining() == 0) null else "server_friend_presence_trailing"
     }
 
     private fun validateLoginFailFrame(frame: ByteArray): String? {
@@ -345,6 +599,42 @@ public object WorldLinkFrameSpecs {
         val priorDisplayName: String,
     )
 
+    public data class ServerPrivateMessagePayload(
+        val senderWorldId: Int,
+        val fromCharacterId: Int,
+        val toCharacterId: Int,
+        val senderCrown: Int,
+        val senderDisplayName: String,
+        val message: String,
+    )
+
+    public data class CentralSocialSnapshot(
+        val publicChat: Int,
+        val privateChat: Int,
+        val tradeChat: Int,
+        val friends: List<CentralSocialFriend>,
+        val ignores: List<CentralSocialIgnore>,
+    )
+
+    public data class CentralSocialFriend(
+        val displayName: String,
+        val previousDisplayName: String?,
+        val worldId: Int,
+    )
+
+    public data class CentralSocialIgnore(
+        val displayName: String,
+        val previousDisplayName: String?,
+    )
+
+    public data class ServerFriendPresencePayload(
+        val ownerCharacterId: Int,
+        val friendCharacterId: Int,
+        val friendWorldId: Int,
+        val friendDisplayName: String,
+        val friendPreviousDisplayName: String?,
+    )
+
     public fun decodeServerRevokeLogin(frame: ByteArray): ServerRevokeLoginPayload {
         val buf = ByteBuffer.wrap(frame, 1, frame.size - 1)
         return ServerRevokeLoginPayload(buf.long, buf.int)
@@ -393,11 +683,138 @@ public object WorldLinkFrameSpecs {
         )
     }
 
+    public fun decodeServerPrivateMessage(frame: ByteArray): ServerPrivateMessagePayload {
+        val buf = ByteBuffer.wrap(frame)
+        buf.get() // opcode
+
+        val senderWorldId = buf.int
+        val fromCharacterId = buf.int
+        val toCharacterId = buf.int
+        val senderCrown = buf.get().toInt() and 0xFF
+        val senderDisplayName = readSocialUtf8(buf)
+        val message = readSocialUtf8(buf)
+
+        return ServerPrivateMessagePayload(
+            senderWorldId = senderWorldId,
+            fromCharacterId = fromCharacterId,
+            toCharacterId = toCharacterId,
+            senderCrown = senderCrown,
+            senderDisplayName = senderDisplayName,
+            message = message,
+        )
+    }
+
+    public fun decodeSocialSnapshot(frame: ByteArray): CentralSocialSnapshot {
+        val buf = ByteBuffer.wrap(frame, 1, frame.size - 1)
+
+        val publicChat = buf.get().toInt() and 0xFF
+        val privateChat = buf.get().toInt() and 0xFF
+        val tradeChat = buf.get().toInt() and 0xFF
+
+        val friends = mutableListOf<CentralSocialFriend>()
+        val friendCount = buf.short.toInt() and 0xFFFF
+
+        repeat(friendCount) {
+            val name = readUtf16LengthPrefixed(buf)
+            val previous = readUtf16LengthPrefixed(buf).ifBlank { null }
+            val worldId = buf.int
+
+            friends +=
+                CentralSocialFriend(
+                    displayName = name,
+                    previousDisplayName = previous,
+                    worldId = worldId,
+                )
+        }
+
+        val ignores = mutableListOf<CentralSocialIgnore>()
+        val ignoreCount = buf.short.toInt() and 0xFFFF
+
+        repeat(ignoreCount) {
+            val name = readUtf16LengthPrefixed(buf)
+            val previous = readUtf16LengthPrefixed(buf).ifBlank { null }
+
+            ignores +=
+                CentralSocialIgnore(
+                    displayName = name,
+                    previousDisplayName = previous,
+                )
+        }
+
+        return CentralSocialSnapshot(
+            publicChat = publicChat,
+            privateChat = privateChat,
+            tradeChat = tradeChat,
+            friends = friends,
+            ignores = ignores,
+        )
+    }
+
+    public fun decodeServerFriendPresence(frame: ByteArray): ServerFriendPresencePayload {
+        val buf = ByteBuffer.wrap(frame, 1, frame.size - 1)
+
+        val ownerCharacterId = buf.int
+        val friendCharacterId = buf.int
+        val friendWorldId = buf.int
+        val displayName = readSocialUtf8(buf)
+        val previousDisplayName = readSocialUtf8(buf).ifBlank { null }
+
+        return ServerFriendPresencePayload(
+            ownerCharacterId = ownerCharacterId,
+            friendCharacterId = friendCharacterId,
+            friendWorldId = friendWorldId,
+            friendDisplayName = displayName,
+            friendPreviousDisplayName = previousDisplayName,
+        )
+    }
+
     private fun readUtf16LengthPrefixed(buf: ByteBuffer): String {
         val len = buf.short.toInt() and 0xFFFF
         val bytes = ByteArray(len)
         buf.get(bytes)
         return String(bytes, StandardCharsets.UTF_8)
+    }
+
+    private fun readCheckedUtf8Length(
+        buf: ByteBuffer,
+        max: Int,
+    ): Int? {
+        if (buf.remaining() < 2) {
+            return null
+        }
+
+        val len = buf.short.toInt() and 0xFFFF
+        if (len > max) {
+            return -1
+        }
+
+        return len
+    }
+
+    private fun readSocialUtf8(buf: ByteBuffer): String {
+        val len = buf.short.toInt() and 0xFFFF
+        val bytes = ByteArray(len)
+        buf.get(bytes)
+        return String(bytes, StandardCharsets.UTF_8)
+    }
+
+    private fun skipSocialUtf8(buf: ByteBuffer): Boolean {
+        if (buf.remaining() < 2) {
+            return false
+        }
+
+        val len = buf.short.toInt() and 0xFFFF
+
+        if (len > SOCIAL_NAME_MAX_UTF8) {
+            return false
+        }
+
+        if (buf.remaining() < len) {
+            return false
+        }
+
+        buf.position(buf.position() + len)
+        return true
     }
 
 

--- a/api/net/src/main/kotlin/org/rsmod/api/net/central/WorldLinkPacketDsl.kt
+++ b/api/net/src/main/kotlin/org/rsmod/api/net/central/WorldLinkPacketDsl.kt
@@ -173,12 +173,26 @@ internal object WorldLinkPackets {
         value: String,
         maxBytes: Int,
     ) {
-        val bytes = value.toByteArray(StandardCharsets.UTF_8)
-        require(bytes.size <= maxBytes) {
-            "World-link UTF-8 value exceeds max length: ${bytes.size} > $maxBytes"
-        }
+        val bytes = utf8TruncatedTo(value, maxBytes)
         writeShort(bytes.size)
         write(bytes)
+    }
+
+    private fun utf8TruncatedTo(
+        value: String,
+        maxBytes: Int,
+    ): ByteArray {
+        val full = value.toByteArray(StandardCharsets.UTF_8)
+        if (full.size <= maxBytes) {
+            return full
+        }
+
+        var cut = maxBytes
+        while (cut > 0 && (full[cut - 1].toInt() and 0xC0) == 0x80) {
+            cut--
+        }
+
+        return full.copyOf(cut)
     }
 
     fun socialSync(
@@ -190,6 +204,15 @@ internal object WorldLinkPackets {
             d.writeByte(WorldLinkFrameSpecs.OP_WORLD_SOCIAL_SYNC)
             d.writeToken(sessionToken)
             d.writeInt(characterId)
+        }
+        return bos.toByteArray()
+    }
+
+    fun heartbeat(sessionToken: ByteArray): ByteArray {
+        val bos = ByteArrayOutputStream(64)
+        DataOutputStream(bos).use { d ->
+            d.writeByte(WorldLinkFrameSpecs.OP_HEARTBEAT)
+            d.writeToken(sessionToken)
         }
         return bos.toByteArray()
     }

--- a/api/net/src/main/kotlin/org/rsmod/api/net/central/WorldLinkPacketDsl.kt
+++ b/api/net/src/main/kotlin/org/rsmod/api/net/central/WorldLinkPacketDsl.kt
@@ -15,6 +15,8 @@ public inline fun ByteArray.dispatchCentralServerPush(
     crossinline onReboot: (WorldLinkFrameSpecs.ServerRebootPayload) -> Unit = {},
     crossinline onBroadcast: (WorldLinkFrameSpecs.ServerBroadcastPayload) -> Unit = {},
     crossinline onDisplayNameSync: (WorldLinkFrameSpecs.ServerDisplayNameSyncPayload) -> Unit = {},
+    crossinline onPrivateMessage: (WorldLinkFrameSpecs.ServerPrivateMessagePayload) -> Unit = {},
+    crossinline onFriendPresence: (WorldLinkFrameSpecs.ServerFriendPresencePayload) -> Unit = {},
     crossinline onOther: (Int) -> Unit = {},
 ) {
     when (val op = this[0].toInt() and 0xFF) {
@@ -24,6 +26,10 @@ public inline fun ByteArray.dispatchCentralServerPush(
         WorldLinkFrameSpecs.OP_SERVER_REBOOT -> onReboot(WorldLinkFrameSpecs.decodeServerReboot(this))
         WorldLinkFrameSpecs.OP_SERVER_BROADCAST -> onBroadcast(WorldLinkFrameSpecs.decodeServerBroadcast(this))
         WorldLinkFrameSpecs.OP_SERVER_DISPLAY_NAME_SYNC -> onDisplayNameSync(WorldLinkFrameSpecs.decodeServerDisplayNameSync(this))
+        WorldLinkFrameSpecs.OP_SERVER_PRIVATE_MESSAGE -> onPrivateMessage(WorldLinkFrameSpecs.decodeServerPrivateMessage(this))
+        WorldLinkFrameSpecs.OP_SERVER_FRIEND_PRESENCE -> {
+            onFriendPresence(WorldLinkFrameSpecs.decodeServerFriendPresence(this))
+        }
         else -> onOther(op)
     }
 }
@@ -73,6 +79,117 @@ internal object WorldLinkPackets {
             d.writeByte(WorldLinkFrameSpecs.OP_LOGOUT)
             d.writeShort(sessionToken.size)
             d.write(sessionToken)
+        }
+        return bos.toByteArray()
+    }
+
+    fun privateMessageRelay(
+        sessionToken: ByteArray,
+        fromCharacterId: Int,
+        targetName: String,
+        senderDisplayName: String,
+        senderCrown: Int,
+        message: String,
+    ): ByteArray {
+        val bos = ByteArrayOutputStream(256)
+        DataOutputStream(bos).use { d ->
+            d.writeByte(WorldLinkFrameSpecs.OP_WORLD_PM_RELAY)
+            d.writeToken(sessionToken)
+            d.writeInt(fromCharacterId)
+            d.writeByte(senderCrown.coerceIn(0, 255))
+            d.writeUtf8(targetName, WorldLinkFrameSpecs.SOCIAL_NAME_MAX_UTF8)
+            d.writeUtf8(senderDisplayName, WorldLinkFrameSpecs.PM_RELAY_SENDER_DISPLAY_MAX_UTF8)
+            d.writeUtf8(message, WorldLinkFrameSpecs.PM_RELAY_MESSAGE_MAX_UTF8)
+        }
+        return bos.toByteArray()
+    }
+
+    fun friendAdd(
+        sessionToken: ByteArray,
+        characterId: Int,
+        targetName: String,
+    ): ByteArray = socialNameAction(WorldLinkFrameSpecs.OP_WORLD_FRIEND_ADD, sessionToken, characterId, targetName)
+
+    fun friendDelete(
+        sessionToken: ByteArray,
+        characterId: Int,
+        targetName: String,
+    ): ByteArray = socialNameAction(WorldLinkFrameSpecs.OP_WORLD_FRIEND_DEL, sessionToken, characterId, targetName)
+
+    fun ignoreAdd(
+        sessionToken: ByteArray,
+        characterId: Int,
+        targetName: String,
+    ): ByteArray = socialNameAction(WorldLinkFrameSpecs.OP_WORLD_IGNORE_ADD, sessionToken, characterId, targetName)
+
+    fun ignoreDelete(
+        sessionToken: ByteArray,
+        characterId: Int,
+        targetName: String,
+    ): ByteArray = socialNameAction(WorldLinkFrameSpecs.OP_WORLD_IGNORE_DEL, sessionToken, characterId, targetName)
+
+    fun privateChatFilter(
+        sessionToken: ByteArray,
+        characterId: Int,
+        privateChatFilter: Int,
+    ): ByteArray {
+        val bos = ByteArrayOutputStream(64)
+        DataOutputStream(bos).use { d ->
+            d.writeByte(WorldLinkFrameSpecs.OP_WORLD_CHAT_FILTERS)
+            d.writeToken(sessionToken)
+            d.writeInt(characterId)
+
+            // Public/trade are intentionally ignored by Central social.
+            // Keep these bytes for wire compatibility with the existing frame shape.
+            d.writeByte(0)
+            d.writeByte(privateChatFilter.coerceIn(0, 2))
+            d.writeByte(0)
+        }
+        return bos.toByteArray()
+    }
+
+    private fun socialNameAction(
+        opcode: Int,
+        sessionToken: ByteArray,
+        characterId: Int,
+        targetName: String,
+    ): ByteArray {
+        val bos = ByteArrayOutputStream(128)
+        DataOutputStream(bos).use { d ->
+            d.writeByte(opcode)
+            d.writeToken(sessionToken)
+            d.writeInt(characterId)
+            d.writeUtf8(targetName, WorldLinkFrameSpecs.SOCIAL_NAME_MAX_UTF8)
+        }
+        return bos.toByteArray()
+    }
+
+    private fun DataOutputStream.writeToken(sessionToken: ByteArray) {
+        writeShort(sessionToken.size)
+        write(sessionToken)
+    }
+
+    private fun DataOutputStream.writeUtf8(
+        value: String,
+        maxBytes: Int,
+    ) {
+        val bytes = value.toByteArray(StandardCharsets.UTF_8)
+        require(bytes.size <= maxBytes) {
+            "World-link UTF-8 value exceeds max length: ${bytes.size} > $maxBytes"
+        }
+        writeShort(bytes.size)
+        write(bytes)
+    }
+
+    fun socialSync(
+        sessionToken: ByteArray,
+        characterId: Int,
+    ): ByteArray {
+        val bos = ByteArrayOutputStream(64)
+        DataOutputStream(bos).use { d ->
+            d.writeByte(WorldLinkFrameSpecs.OP_WORLD_SOCIAL_SYNC)
+            d.writeToken(sessionToken)
+            d.writeInt(characterId)
         }
         return bos.toByteArray()
     }

--- a/api/net/src/main/kotlin/org/rsmod/api/net/central/embed/CentralEmbeddedLifecycle.kt
+++ b/api/net/src/main/kotlin/org/rsmod/api/net/central/embed/CentralEmbeddedLifecycle.kt
@@ -33,7 +33,7 @@ constructor(
                 Triple(
                     jdbcFromYaml,
                     pg.user.trim().ifBlank { "openrune" },
-                    pg.password,
+                    pg.password.trim().ifBlank { "openrune" },
                 )
             } else {
                 val embeddedCreds =
@@ -43,7 +43,20 @@ constructor(
                                 "Ensure [org.rsmod.server.app.GameBootstrap] calls " +
                                 "`EmbeddedSameInstancePostgres.ensureStarted` before starting embedded Central.",
                         )
-                embeddedCreds
+
+                val embeddedJdbc = embeddedCreds.first
+                val embeddedUser = embeddedCreds.second.trim().ifBlank {
+                    pg.user.trim().ifBlank { "postgres" }
+                }
+                val embeddedPassword = embeddedCreds.third.trim().ifBlank {
+                    pg.password.trim().ifBlank { "openrune" }
+                }
+
+                Triple(
+                    embeddedJdbc,
+                    embeddedUser,
+                    embeddedPassword,
+                )
             }
 
         val usesEmbeddedJdbc = jdbcFromYaml.isEmpty()

--- a/api/net/src/main/kotlin/org/rsmod/api/net/rsprot/NetworkScript.kt
+++ b/api/net/src/main/kotlin/org/rsmod/api/net/rsprot/NetworkScript.kt
@@ -27,6 +27,8 @@ import org.rsmod.game.entity.player.SessionStateEvent
 import org.rsmod.plugin.scripts.PluginScript
 import org.rsmod.plugin.scripts.ScriptContext
 
+private const val CENTRAL_SOCIAL_HEARTBEAT_INTERVAL_MS = 30_000L
+
 @OptIn(ExperimentalUnsignedTypes::class, ExperimentalStdlibApi::class)
 class NetworkScript
 @Inject
@@ -83,6 +85,7 @@ constructor(
         service.infoProtocols.update()
         if (openRuneCentral.isEnabled) {
             openRuneCentral.drainInboundRevokesOnGameThread(playerRegistry, gameUpdate)
+            heartbeatCentralSocialSessions(openRuneCentral, playerRegistry)
         }
     }
 
@@ -104,6 +107,55 @@ constructor(
     private fun SessionStateEvent.Delete.closeSession() {
         val client = player.client as? RspClient ?: return
         client.unregister(service, player)
+    }
+
+    @Volatile
+    private var centralSocialHeartbeatInFlight: Boolean = false
+
+    private var nextCentralSocialHeartbeatAt: Long = 0L
+
+    private fun heartbeatCentralSocialSessions(
+        central: OpenRuneCentralWorldLink,
+        playerRegistry: PlayerRegistry,
+    ) {
+        val now = System.currentTimeMillis()
+        if (now < nextCentralSocialHeartbeatAt) {
+            return
+        }
+
+        nextCentralSocialHeartbeatAt = now + CENTRAL_SOCIAL_HEARTBEAT_INTERVAL_MS
+
+        val tokens = mutableListOf<ByteArray>()
+        playerRegistry.forEachOnline { player ->
+            val token = player.openRuneCentralSessionToken ?: return@forEachOnline
+            tokens += token.copyOf()
+        }
+
+        if (tokens.isEmpty()) {
+            return
+        }
+
+        if (centralSocialHeartbeatInFlight) {
+            return
+        }
+
+        centralSocialHeartbeatInFlight = true
+
+        Thread(
+            {
+                try {
+                    for (token in tokens) {
+                        central.heartbeat(token)
+                    }
+                } finally {
+                    centralSocialHeartbeatInFlight = false
+                }
+            },
+            "openrune-central-social-heartbeat",
+        ).apply {
+            isDaemon = true
+            start()
+        }
     }
 
     private fun SessionStateEvent.Login.markDbOnlineSession() {

--- a/api/net/src/main/kotlin/org/rsmod/api/net/rsprot/handlers/FriendListAddHandler.kt
+++ b/api/net/src/main/kotlin/org/rsmod/api/net/rsprot/handlers/FriendListAddHandler.kt
@@ -1,0 +1,95 @@
+package org.rsmod.api.net.rsprot.handlers
+
+import jakarta.inject.Inject
+import net.rsprot.protocol.game.incoming.social.FriendListAdd
+import org.rsmod.api.db.gateway.GameDbManager
+import org.rsmod.api.db.gateway.model.fold
+import org.rsmod.api.net.central.CentralSocialService
+import org.rsmod.api.net.central.CentralSocialResult
+import org.rsmod.api.net.central.OpenRuneCentralWorldLink
+import org.rsmod.api.net.central.writeCentralSocialSnapshot
+import org.rsmod.api.social.writeSocialMessage
+import org.rsmod.game.entity.Player
+import org.rsmod.game.entity.PlayerList
+
+class FriendListAddHandler
+@Inject
+constructor(
+    private val playerList: PlayerList,
+    private val db: GameDbManager,
+    private val social: CentralSocialService,
+) : MessageHandler<FriendListAdd> {
+    override fun handle(player: Player, message: FriendListAdd) {
+        val uid = player.uid
+        val requestedName = message.name
+        val token = player.openRuneCentralSessionToken
+        val characterId = player.characterId
+
+        if (token == null || characterId <= 0) {
+            player.writeSocialMessage("Social is not available right now.")
+            return
+        }
+
+        db.request(
+            request = {
+                social.addFriend(
+                    sessionToken = token,
+                    characterId = characterId,
+                    name = requestedName,
+                )
+            },
+            response = { result ->
+                val current = uid.resolve(playerList) ?: return@request
+
+                result.fold(
+                    onOk = { socialResult ->
+                        when (socialResult) {
+                            CentralSocialResult.Ok -> {
+                                val refreshUid = current.uid
+
+                                db.request(
+                                    request = {
+                                        social.socialSnapshot(
+                                            sessionToken = token,
+                                            characterId = characterId,
+                                        )
+                                    },
+                                    response = { refreshResult ->
+                                        val refreshed =
+                                            refreshUid.resolve(playerList) ?: return@request
+
+                                        refreshResult.fold(
+                                            onOk = { sync ->
+                                                when (sync) {
+                                                    is OpenRuneCentralWorldLink.CentralSocialSnapshotResult.Ok -> {
+                                                        refreshed.writeCentralSocialSnapshot(sync.snapshot)
+                                                    }
+
+                                                    is OpenRuneCentralWorldLink.CentralSocialSnapshotResult.Failed -> {
+                                                        refreshed.writeSocialMessage(sync.message)
+                                                    }
+                                                }
+                                            },
+                                            onErr = {
+                                                refreshed.writeSocialMessage("Unable to refresh social list right now.")
+                                            },
+                                        )
+                                    },
+                                )
+                            }
+
+                            CentralSocialResult.Ignored -> Unit
+
+                            is CentralSocialResult.Failed -> {
+                                current.writeSocialMessage(socialResult.message)
+                            }
+                        }
+                    },
+                    onErr = {
+                        current.writeSocialMessage("Unable to add player right now.")
+                    },
+                )
+            },
+        )
+    }
+}

--- a/api/net/src/main/kotlin/org/rsmod/api/net/rsprot/handlers/FriendListDeleteHandler.kt
+++ b/api/net/src/main/kotlin/org/rsmod/api/net/rsprot/handlers/FriendListDeleteHandler.kt
@@ -1,0 +1,95 @@
+package org.rsmod.api.net.rsprot.handlers
+
+import jakarta.inject.Inject
+import net.rsprot.protocol.game.incoming.social.FriendListDel
+import org.rsmod.api.db.gateway.GameDbManager
+import org.rsmod.api.db.gateway.model.fold
+import org.rsmod.api.net.central.CentralSocialResult
+import org.rsmod.api.net.central.CentralSocialService
+import org.rsmod.api.net.central.OpenRuneCentralWorldLink
+import org.rsmod.api.net.central.writeCentralSocialSnapshot
+import org.rsmod.api.social.writeSocialMessage
+import org.rsmod.game.entity.Player
+import org.rsmod.game.entity.PlayerList
+
+class FriendListDeleteHandler
+@Inject
+constructor(
+    private val playerList: PlayerList,
+    private val db: GameDbManager,
+    private val social: CentralSocialService,
+) : MessageHandler<FriendListDel> {
+    override fun handle(player: Player, message: FriendListDel) {
+        val uid = player.uid
+        val requestedName = message.name
+        val token = player.openRuneCentralSessionToken
+        val characterId = player.characterId
+
+        if (token == null || characterId <= 0) {
+            player.writeSocialMessage("Social is not available right now.")
+            return
+        }
+
+        db.request(
+            request = {
+                social.deleteFriend(
+                    sessionToken = token,
+                    characterId = characterId,
+                    name = requestedName,
+                )
+            },
+            response = { result ->
+                val current = uid.resolve(playerList) ?: return@request
+
+                result.fold(
+                    onOk = { socialResult ->
+                        when (socialResult) {
+                            CentralSocialResult.Ok -> {
+                                val refreshUid = current.uid
+
+                                db.request(
+                                    request = {
+                                        social.socialSnapshot(
+                                            sessionToken = token,
+                                            characterId = characterId,
+                                        )
+                                    },
+                                    response = { refreshResult ->
+                                        val refreshed =
+                                            refreshUid.resolve(playerList) ?: return@request
+
+                                        refreshResult.fold(
+                                            onOk = { sync ->
+                                                when (sync) {
+                                                    is OpenRuneCentralWorldLink.CentralSocialSnapshotResult.Ok -> {
+                                                        refreshed.writeCentralSocialSnapshot(sync.snapshot)
+                                                    }
+
+                                                    is OpenRuneCentralWorldLink.CentralSocialSnapshotResult.Failed -> {
+                                                        refreshed.writeSocialMessage(sync.message)
+                                                    }
+                                                }
+                                            },
+                                            onErr = {
+                                                refreshed.writeSocialMessage("Unable to refresh social list right now.")
+                                            },
+                                        )
+                                    },
+                                )
+                            }
+
+                            CentralSocialResult.Ignored -> Unit
+
+                            is CentralSocialResult.Failed -> {
+                                current.writeSocialMessage(socialResult.message)
+                            }
+                        }
+                    },
+                    onErr = {
+                        current.writeSocialMessage("Unable to delete friend right now.")
+                    },
+                )
+            },
+        )
+    }
+}

--- a/api/net/src/main/kotlin/org/rsmod/api/net/rsprot/handlers/IgnoreListAddHandler.kt
+++ b/api/net/src/main/kotlin/org/rsmod/api/net/rsprot/handlers/IgnoreListAddHandler.kt
@@ -1,0 +1,95 @@
+package org.rsmod.api.net.rsprot.handlers
+
+import jakarta.inject.Inject
+import net.rsprot.protocol.game.incoming.social.IgnoreListAdd
+import org.rsmod.api.db.gateway.GameDbManager
+import org.rsmod.api.db.gateway.model.fold
+import org.rsmod.api.net.central.CentralSocialResult
+import org.rsmod.api.net.central.CentralSocialService
+import org.rsmod.api.net.central.OpenRuneCentralWorldLink
+import org.rsmod.api.net.central.writeCentralSocialSnapshot
+import org.rsmod.api.social.writeSocialMessage
+import org.rsmod.game.entity.Player
+import org.rsmod.game.entity.PlayerList
+
+class IgnoreListAddHandler
+@Inject
+constructor(
+    private val playerList: PlayerList,
+    private val db: GameDbManager,
+    private val social: CentralSocialService,
+) : MessageHandler<IgnoreListAdd> {
+    override fun handle(player: Player, message: IgnoreListAdd) {
+        val uid = player.uid
+        val requestedName = message.name
+        val token = player.openRuneCentralSessionToken
+        val characterId = player.characterId
+
+        if (token == null || characterId <= 0) {
+            player.writeSocialMessage("Social is not available right now.")
+            return
+        }
+
+        db.request(
+            request = {
+                social.addIgnore(
+                    sessionToken = token,
+                    characterId = characterId,
+                    name = requestedName,
+                )
+            },
+            response = { result ->
+                val current = uid.resolve(playerList) ?: return@request
+
+                result.fold(
+                    onOk = { socialResult ->
+                        when (socialResult) {
+                            CentralSocialResult.Ok -> {
+                                val refreshUid = current.uid
+
+                                db.request(
+                                    request = {
+                                        social.socialSnapshot(
+                                            sessionToken = token,
+                                            characterId = characterId,
+                                        )
+                                    },
+                                    response = { refreshResult ->
+                                        val refreshed =
+                                            refreshUid.resolve(playerList) ?: return@request
+
+                                        refreshResult.fold(
+                                            onOk = { sync ->
+                                                when (sync) {
+                                                    is OpenRuneCentralWorldLink.CentralSocialSnapshotResult.Ok -> {
+                                                        refreshed.writeCentralSocialSnapshot(sync.snapshot)
+                                                    }
+
+                                                    is OpenRuneCentralWorldLink.CentralSocialSnapshotResult.Failed -> {
+                                                        refreshed.writeSocialMessage(sync.message)
+                                                    }
+                                                }
+                                            },
+                                            onErr = {
+                                                refreshed.writeSocialMessage("Unable to refresh social list right now.")
+                                            },
+                                        )
+                                    },
+                                )
+                            }
+
+                            CentralSocialResult.Ignored -> Unit
+
+                            is CentralSocialResult.Failed -> {
+                                current.writeSocialMessage(socialResult.message)
+                            }
+                        }
+                    },
+                    onErr = {
+                        current.writeSocialMessage("Unable to ignore player right now.")
+                    },
+                )
+            },
+        )
+    }
+}

--- a/api/net/src/main/kotlin/org/rsmod/api/net/rsprot/handlers/IgnoreListDeleteHandler.kt
+++ b/api/net/src/main/kotlin/org/rsmod/api/net/rsprot/handlers/IgnoreListDeleteHandler.kt
@@ -1,0 +1,95 @@
+package org.rsmod.api.net.rsprot.handlers
+
+import jakarta.inject.Inject
+import net.rsprot.protocol.game.incoming.social.IgnoreListDel
+import org.rsmod.api.db.gateway.GameDbManager
+import org.rsmod.api.db.gateway.model.fold
+import org.rsmod.api.net.central.CentralSocialResult
+import org.rsmod.api.net.central.CentralSocialService
+import org.rsmod.api.net.central.OpenRuneCentralWorldLink
+import org.rsmod.api.net.central.writeCentralSocialSnapshot
+import org.rsmod.api.social.writeSocialMessage
+import org.rsmod.game.entity.Player
+import org.rsmod.game.entity.PlayerList
+
+class IgnoreListDeleteHandler
+@Inject
+constructor(
+    private val playerList: PlayerList,
+    private val db: GameDbManager,
+    private val social: CentralSocialService,
+) : MessageHandler<IgnoreListDel> {
+    override fun handle(player: Player, message: IgnoreListDel) {
+        val uid = player.uid
+        val requestedName = message.name
+        val token = player.openRuneCentralSessionToken
+        val characterId = player.characterId
+
+        if (token == null || characterId <= 0) {
+            player.writeSocialMessage("Social is not available right now.")
+            return
+        }
+
+        db.request(
+            request = {
+                social.deleteIgnore(
+                    sessionToken = token,
+                    characterId = characterId,
+                    name = requestedName,
+                )
+            },
+            response = { result ->
+                val current = uid.resolve(playerList) ?: return@request
+
+                result.fold(
+                    onOk = { socialResult ->
+                        when (socialResult) {
+                            CentralSocialResult.Ok -> {
+                                val refreshUid = current.uid
+
+                                db.request(
+                                    request = {
+                                        social.socialSnapshot(
+                                            sessionToken = token,
+                                            characterId = characterId,
+                                        )
+                                    },
+                                    response = { refreshResult ->
+                                        val refreshed =
+                                            refreshUid.resolve(playerList) ?: return@request
+
+                                        refreshResult.fold(
+                                            onOk = { sync ->
+                                                when (sync) {
+                                                    is OpenRuneCentralWorldLink.CentralSocialSnapshotResult.Ok -> {
+                                                        refreshed.writeCentralSocialSnapshot(sync.snapshot)
+                                                    }
+
+                                                    is OpenRuneCentralWorldLink.CentralSocialSnapshotResult.Failed -> {
+                                                        refreshed.writeSocialMessage(sync.message)
+                                                    }
+                                                }
+                                            },
+                                            onErr = {
+                                                refreshed.writeSocialMessage("Unable to refresh social list right now.")
+                                            },
+                                        )
+                                    },
+                                )
+                            }
+
+                            CentralSocialResult.Ignored -> Unit
+
+                            is CentralSocialResult.Failed -> {
+                                current.writeSocialMessage(socialResult.message)
+                            }
+                        }
+                    },
+                    onErr = {
+                        current.writeSocialMessage("Unable to delete ignore right now.")
+                    },
+                )
+            },
+        )
+    }
+}

--- a/api/net/src/main/kotlin/org/rsmod/api/net/rsprot/handlers/MessagePrivateHandler.kt
+++ b/api/net/src/main/kotlin/org/rsmod/api/net/rsprot/handlers/MessagePrivateHandler.kt
@@ -1,0 +1,75 @@
+package org.rsmod.api.net.rsprot.handlers
+
+import jakarta.inject.Inject
+import net.rsprot.protocol.game.incoming.messaging.MessagePrivate
+import net.rsprot.protocol.game.outgoing.social.MessagePrivateEcho
+import org.rsmod.api.db.gateway.GameDbManager
+import org.rsmod.api.db.gateway.model.fold
+import org.rsmod.api.net.central.CentralSocialResult
+import org.rsmod.api.net.central.CentralSocialService
+import org.rsmod.api.social.writeSocialMessage
+import org.rsmod.game.entity.Player
+import org.rsmod.game.entity.PlayerList
+
+class MessagePrivateHandler
+@Inject
+constructor(
+    private val playerList: PlayerList,
+    private val db: GameDbManager,
+    private val social: CentralSocialService,
+) : MessageHandler<MessagePrivate> {
+    override fun handle(player: Player, message: MessagePrivate) {
+        val uid = player.uid
+        val targetName = message.name
+        val text = message.message
+        val token = player.openRuneCentralSessionToken
+        val characterId = player.characterId
+        val senderDisplayName = player.displayName.ifBlank { player.username }
+        val senderCrown = player.modLevel.clientCode
+
+        if (token == null || characterId <= 0) {
+            player.writeSocialMessage("Private messaging is not available right now.")
+            return
+        }
+
+        db.request(
+            request = {
+                social.sendPrivateMessage(
+                    sessionToken = token,
+                    fromCharacterId = characterId,
+                    targetName = targetName,
+                    senderDisplayName = senderDisplayName,
+                    senderCrown = senderCrown,
+                    message = text,
+                )
+            },
+            response = { result ->
+                val current = uid.resolve(playerList) ?: return@request
+
+                result.fold(
+                    onOk = { socialResult ->
+                        when (socialResult) {
+                            CentralSocialResult.Ok -> {
+                                current.client.write(
+                                    MessagePrivateEcho(
+                                        recipient = targetName,
+                                        message = text.trim(),
+                                    )
+                                )
+                            }
+
+                            CentralSocialResult.Ignored -> Unit
+
+                            is CentralSocialResult.Failed -> {
+                                current.writeSocialMessage(socialResult.message)
+                            }
+                        }
+                    },
+                    onErr = {
+                        current.writeSocialMessage("Unable to send private message right now.")
+                    },
+                )
+            },
+        )
+    }
+}

--- a/api/net/src/main/kotlin/org/rsmod/api/net/rsprot/handlers/MessagePrivateHandler.kt
+++ b/api/net/src/main/kotlin/org/rsmod/api/net/rsprot/handlers/MessagePrivateHandler.kt
@@ -11,6 +11,8 @@ import org.rsmod.api.social.writeSocialMessage
 import org.rsmod.game.entity.Player
 import org.rsmod.game.entity.PlayerList
 
+private const val PRIVATE_MESSAGE_MAX_CHARS = 255
+
 class MessagePrivateHandler
 @Inject
 constructor(
@@ -21,7 +23,7 @@ constructor(
     override fun handle(player: Player, message: MessagePrivate) {
         val uid = player.uid
         val targetName = message.name
-        val text = message.message
+        val text = message.message.trim().take(PRIVATE_MESSAGE_MAX_CHARS)
         val token = player.openRuneCentralSessionToken
         val characterId = player.characterId
         val senderDisplayName = player.displayName.ifBlank { player.username }

--- a/api/net/src/main/kotlin/org/rsmod/api/net/rsprot/handlers/MessagePublicHandler.kt
+++ b/api/net/src/main/kotlin/org/rsmod/api/net/rsprot/handlers/MessagePublicHandler.kt
@@ -6,6 +6,17 @@ import org.rsmod.game.entity.player.PublicMessage
 
 class MessagePublicHandler : MessageHandler<MessagePublic> {
     override fun handle(player: Player, message: MessagePublic) {
+        /*
+         * TODO(social): Ignore list currently blocks ignored public chat from the
+         *  chatbox through the client ignore list, but overhead public-chat bubbles are
+         *  still sent by the player-info public-message mask. For stricter ignore
+         *  behavior, possibly filter PublicMessage masks per receiver before sending player info.
+         *
+         * TODO(trade):
+         *  - When trade is implemented, trade requests should be blocked when
+         *  either side has the other ignored.
+            */
+
         val publicMessage =
             PublicMessage(
                 text = message.message,

--- a/api/net/src/main/kotlin/org/rsmod/api/net/rsprot/handlers/SetChatFilterSettingsHandler.kt
+++ b/api/net/src/main/kotlin/org/rsmod/api/net/rsprot/handlers/SetChatFilterSettingsHandler.kt
@@ -1,0 +1,59 @@
+package org.rsmod.api.net.rsprot.handlers
+
+import jakarta.inject.Inject
+import net.rsprot.protocol.game.incoming.misc.user.SetChatFilterSettings
+import org.rsmod.api.db.gateway.GameDbManager
+import org.rsmod.api.db.gateway.model.fold
+import org.rsmod.api.net.central.CentralSocialResult
+import org.rsmod.api.net.central.CentralSocialService
+import org.rsmod.api.social.writeSocialMessage
+import org.rsmod.game.entity.Player
+import org.rsmod.game.entity.PlayerList
+
+class SetChatFilterSettingsHandler
+@Inject
+constructor(
+    private val playerList: PlayerList,
+    private val db: GameDbManager,
+    private val social: CentralSocialService,
+) : MessageHandler<SetChatFilterSettings> {
+    override fun handle(player: Player, message: SetChatFilterSettings) {
+        val uid = player.uid
+        val token = player.openRuneCentralSessionToken
+        val characterId = player.characterId
+
+        if (token == null || characterId <= 0) {
+            player.writeSocialMessage("Social settings are not available right now.")
+            return
+        }
+
+        db.request(
+            request = {
+                social.setPrivateChatFilter(
+                    sessionToken = token,
+                    characterId = characterId,
+                    privateChatFilter = message.privateChatFilter,
+                )
+            },
+            response = { result ->
+                val current = uid.resolve(playerList) ?: return@request
+
+                result.fold(
+                    onOk = { socialResult ->
+                        when (socialResult) {
+                            CentralSocialResult.Ok,
+                            CentralSocialResult.Ignored -> Unit
+
+                            is CentralSocialResult.Failed -> {
+                                current.writeSocialMessage(socialResult.message)
+                            }
+                        }
+                    },
+                    onErr = {
+                        current.writeSocialMessage("Unable to update private chat filter right now.")
+                    },
+                )
+            },
+        )
+    }
+}

--- a/api/net/src/main/kotlin/org/rsmod/api/net/rsprot/provider/MessageConsumerProvider.kt
+++ b/api/net/src/main/kotlin/org/rsmod/api/net/rsprot/provider/MessageConsumerProvider.kt
@@ -11,6 +11,7 @@ import net.rsprot.protocol.game.incoming.buttons.IfSubOp
 import net.rsprot.protocol.game.incoming.locs.OpLocV2
 import net.rsprot.protocol.game.incoming.locs.OpLoc6
 import net.rsprot.protocol.game.incoming.locs.OpLocT
+import net.rsprot.protocol.game.incoming.messaging.MessagePrivate
 import net.rsprot.protocol.game.incoming.messaging.MessagePublic
 import net.rsprot.protocol.game.incoming.misc.client.MapBuildComplete
 import net.rsprot.protocol.game.incoming.misc.client.WindowStatus
@@ -19,6 +20,7 @@ import net.rsprot.protocol.game.incoming.misc.user.ClientCheat
 import net.rsprot.protocol.game.incoming.misc.user.CloseModal
 import net.rsprot.protocol.game.incoming.misc.user.MoveGameClick
 import net.rsprot.protocol.game.incoming.misc.user.MoveMinimapClick
+import net.rsprot.protocol.game.incoming.misc.user.SetChatFilterSettings
 import net.rsprot.protocol.game.incoming.npcs.OpNpcV2
 import net.rsprot.protocol.game.incoming.npcs.OpNpc6
 import net.rsprot.protocol.game.incoming.npcs.OpNpcT
@@ -31,17 +33,26 @@ import net.rsprot.protocol.game.incoming.resumed.ResumePNameDialog
 import net.rsprot.protocol.game.incoming.resumed.ResumePObjDialog
 import net.rsprot.protocol.game.incoming.resumed.ResumePStringDialog
 import net.rsprot.protocol.game.incoming.resumed.ResumePauseButton
+import net.rsprot.protocol.game.incoming.social.FriendListAdd
+import net.rsprot.protocol.game.incoming.social.FriendListDel
+import net.rsprot.protocol.game.incoming.social.IgnoreListAdd
+import net.rsprot.protocol.game.incoming.social.IgnoreListDel
 import net.rsprot.protocol.message.codec.incoming.GameMessageConsumerRepositoryBuilder
 import net.rsprot.protocol.message.codec.incoming.provider.DefaultGameMessageConsumerRepositoryProvider
 import org.rsmod.api.net.rsprot.handlers.ClickWorldMapHandler
 import org.rsmod.api.net.rsprot.handlers.ClientCheatHandler
 import org.rsmod.api.net.rsprot.handlers.CloseModalHandler
+import org.rsmod.api.net.rsprot.handlers.FriendListAddHandler
+import org.rsmod.api.net.rsprot.handlers.FriendListDeleteHandler
 import org.rsmod.api.net.rsprot.handlers.If3ButtonHandler
 import org.rsmod.api.net.rsprot.handlers.IfButtonDHandler
 import org.rsmod.api.net.rsprot.handlers.IfButtonTHandler
 import org.rsmod.api.net.rsprot.handlers.IfScriptTriggerHandler
 import org.rsmod.api.net.rsprot.handlers.IfSubOpHandler
+import org.rsmod.api.net.rsprot.handlers.IgnoreListAddHandler
+import org.rsmod.api.net.rsprot.handlers.IgnoreListDeleteHandler
 import org.rsmod.api.net.rsprot.handlers.MapBuildCompleteHandler
+import org.rsmod.api.net.rsprot.handlers.MessagePrivateHandler
 import org.rsmod.api.net.rsprot.handlers.MessagePublicHandler
 import org.rsmod.api.net.rsprot.handlers.MoveGameClickHandler
 import org.rsmod.api.net.rsprot.handlers.MoveMinimapClickHandler
@@ -60,6 +71,7 @@ import org.rsmod.api.net.rsprot.handlers.ResumePNameDialogHandler
 import org.rsmod.api.net.rsprot.handlers.ResumePObjDialogHandler
 import org.rsmod.api.net.rsprot.handlers.ResumePStringDialogHandler
 import org.rsmod.api.net.rsprot.handlers.ResumePauseButtonHandler
+import org.rsmod.api.net.rsprot.handlers.SetChatFilterSettingsHandler
 import org.rsmod.api.net.rsprot.handlers.WindowStatusHandler
 import org.rsmod.game.entity.Player
 
@@ -81,6 +93,12 @@ constructor(
     private val opPlayer: OpPlayerHandler,
     private val opPlayerT: OpPlayerTHandler,
     private val messagePublic: MessagePublicHandler,
+    private val messagePrivate: MessagePrivateHandler,
+    private val friendListAdd: FriendListAddHandler,
+    private val friendListDelete: FriendListDeleteHandler,
+    private val ignoreListAdd: IgnoreListAddHandler,
+    private val ignoreListDelete: IgnoreListDeleteHandler,
+    private val setChatFilterSettings: SetChatFilterSettingsHandler,
     private val if3Button: If3ButtonHandler,
     private val closeModal: CloseModalHandler,
     private val resumePauseButton: ResumePauseButtonHandler,
@@ -112,6 +130,12 @@ constructor(
         builder.addListener(OpPlayer::class.java, opPlayer)
         builder.addListener(OpPlayerT::class.java, opPlayerT)
         builder.addListener(MessagePublic::class.java, messagePublic)
+        builder.addListener(MessagePrivate::class.java, messagePrivate)
+        builder.addListener(FriendListAdd::class.java, friendListAdd)
+        builder.addListener(FriendListDel::class.java, friendListDelete)
+        builder.addListener(IgnoreListAdd::class.java, ignoreListAdd)
+        builder.addListener(IgnoreListDel::class.java, ignoreListDelete)
+        builder.addListener(SetChatFilterSettings::class.java, setChatFilterSettings)
         builder.addListener(If3Button::class.java, if3Button)
         builder.addListener(CloseModal::class.java, closeModal)
         builder.addListener(ResumePauseButton::class.java, resumePauseButton)

--- a/api/social/build.gradle.kts
+++ b/api/social/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    id("base-conventions")
+}
+
+kotlin {
+    explicitApi()
+}
+
+dependencies {
+    implementation(libs.bundles.logging)
+    implementation(libs.rsprot.api)
+    implementation(libs.rsprot.shared)
+    implementation(libs.guice)
+    implementation(projects.api.attr)
+    implementation(projects.api.playerOutput)
+    implementation(projects.api.player)
+    implementation(projects.engine.events)
+    implementation(projects.engine.game)
+    implementation(projects.api.db)
+    implementation(projects.api.dbGateway)
+    implementation(projects.api.serverConfig)
+}

--- a/api/social/src/main/kotlin/org.rsmod.api.social/SocialPackets.kt
+++ b/api/social/src/main/kotlin/org.rsmod.api.social/SocialPackets.kt
@@ -1,0 +1,134 @@
+package org.rsmod.api.social
+
+import net.rsprot.protocol.game.outgoing.misc.player.ChatFilterSettingsPrivateChat
+import net.rsprot.protocol.game.outgoing.misc.player.MessageGame
+import net.rsprot.protocol.game.outgoing.social.FriendListLoaded
+import net.rsprot.protocol.game.outgoing.social.UpdateFriendList
+import net.rsprot.protocol.game.outgoing.social.UpdateIgnoreList
+import org.rsmod.game.entity.Player
+
+private const val GAME_MESSAGE_TYPE = 0
+private const val LOGIN_LOGOUT_NOTIFICATION_TYPE = 5
+
+public fun Player.writeSocialMessage(message: String) {
+    client.write(MessageGame(type = GAME_MESSAGE_TYPE, message = message))
+}
+
+public fun Player.writeLoginLogoutMessage(message: String) {
+    client.write(MessageGame(type = LOGIN_LOGOUT_NOTIFICATION_TYPE, message = message))
+}
+
+public fun Player.writeSocialLoaded() {
+    client.write(FriendListLoaded)
+}
+
+public fun Player.writePrivateChatFilter(mode: Int) {
+    client.write(ChatFilterSettingsPrivateChat(mode))
+}
+
+public fun Player.writeFriendPresenceDelta(
+    name: String,
+    previousName: String?,
+    worldId: Int,
+) {
+    val cleaned = name.trim()
+    if (cleaned.isBlank()) {
+        return
+    }
+
+    val entry =
+        if (worldId > 0) {
+            UpdateFriendList.OnlineFriend(
+                added = false,
+                name = cleaned,
+                previousName = previousName,
+                worldId = worldId,
+                rank = 0,
+                properties = 0,
+                notes = "",
+                worldName = "OpenRune",
+                platform = 8,
+                worldFlags = 0,
+            )
+        } else {
+            UpdateFriendList.OfflineFriend(
+                added = false,
+                name = cleaned,
+                previousName = previousName,
+                rank = 0,
+                properties = 0,
+                notes = "",
+            )
+        }
+
+    client.write(UpdateFriendList(listOf(entry)))
+
+    if (worldId > 0) {
+        writeLoginLogoutMessage("$cleaned has logged in.")
+    } else {
+        writeLoginLogoutMessage("$cleaned has logged out.")
+    }
+}
+
+public fun Player.writeFriendAddedDelta(
+    name: String,
+    previousName: String? = null,
+) {
+    val cleaned = name.trim()
+    if (cleaned.isBlank()) {
+        return
+    }
+
+    client.write(
+        UpdateFriendList(
+            listOf(
+                UpdateFriendList.OfflineFriend(
+                    added = true,
+                    name = cleaned,
+                    previousName = previousName,
+                    rank = 0,
+                    properties = 0,
+                    notes = "",
+                )
+            )
+        )
+    )
+}
+
+public fun Player.writeIgnoreAddedDelta(
+    name: String,
+    previousName: String? = null,
+) {
+    val cleaned = name.trim()
+    if (cleaned.isBlank()) {
+        return
+    }
+
+    client.write(
+        UpdateIgnoreList(
+            listOf(
+                UpdateIgnoreList.AddedIgnoredEntry(
+                    name = cleaned,
+                    previousName = previousName,
+                    note = "",
+                    added = true,
+                )
+            )
+        )
+    )
+}
+
+public fun Player.writeIgnoreRemovedDelta(name: String) {
+    val cleaned = name.trim()
+    if (cleaned.isBlank()) {
+        return
+    }
+
+    client.write(
+        UpdateIgnoreList(
+            listOf(
+                UpdateIgnoreList.RemovedIgnoredEntry(cleaned)
+            )
+        )
+    )
+}

--- a/content/interfaces/gameframe/build.gradle.kts
+++ b/content/interfaces/gameframe/build.gradle.kts
@@ -5,4 +5,5 @@ plugins {
 dependencies {
     implementation(projects.api.pluginCommons)
     implementation(projects.api.scriptAdvanced)
+    implementation(projects.api.social)
 }

--- a/content/interfaces/gameframe/src/main/kotlin/org/rsmod/content/interfaces/gameframe/script/FriendIgnoreScript.kt
+++ b/content/interfaces/gameframe/src/main/kotlin/org/rsmod/content/interfaces/gameframe/script/FriendIgnoreScript.kt
@@ -1,0 +1,74 @@
+package org.rsmod.content.interfaces.gameframe.script
+
+import dev.openrune.definition.type.widget.IfEvent
+import jakarta.inject.Inject
+import org.rsmod.api.player.ui.ifOpenOverlay
+import org.rsmod.api.player.ui.ifSetEvents
+import org.rsmod.api.script.onIfOpen
+import org.rsmod.api.script.onIfOverlayButton
+import org.rsmod.events.EventBus
+import org.rsmod.game.entity.Player
+import org.rsmod.plugin.scripts.PluginScript
+import org.rsmod.plugin.scripts.ScriptContext
+
+private object FriendsInterface {
+    const val main: String = "interface.friends"
+}
+
+private object FriendsComponents {
+    const val ignore: String = "component.friends:ignore"
+}
+
+private object IgnoreInterface {
+    const val main: String = "interface.ignore"
+}
+
+private object IgnoreComponents {
+    const val friends: String = "component.ignore:friends"
+}
+
+private object GameframeComponents {
+    const val side9: String = "component.toplevel_osrs_stretch:side9"
+}
+
+class FriendsIgnoreScript
+@Inject
+constructor(
+    private val eventBus: EventBus,
+) : PluginScript() {
+    override fun ScriptContext.startup() {
+        onIfOpen(FriendsInterface.main) {
+            player.enableFriendsIgnoreButton()
+        }
+
+        onIfOpen(IgnoreInterface.main) {
+            player.enableIgnoreFriendsButton()
+        }
+
+        onIfOverlayButton(FriendsComponents.ignore) {
+            player.openIgnoreTab()
+        }
+
+        onIfOverlayButton(IgnoreComponents.friends) {
+            player.openFriendsTab()
+        }
+    }
+
+    private fun Player.enableFriendsIgnoreButton() {
+        ifSetEvents(FriendsComponents.ignore, -1..-1, IfEvent.Op1)
+        ifSetEvents(FriendsComponents.ignore, 0..0, IfEvent.Op1)
+    }
+
+    private fun Player.enableIgnoreFriendsButton() {
+        ifSetEvents(IgnoreComponents.friends, -1..-1, IfEvent.Op1)
+        ifSetEvents(IgnoreComponents.friends, 0..0, IfEvent.Op1)
+    }
+
+    private fun Player.openIgnoreTab() {
+        ifOpenOverlay(IgnoreInterface.main, GameframeComponents.side9, eventBus)
+    }
+
+    private fun Player.openFriendsTab() {
+        ifOpenOverlay(FriendsInterface.main, GameframeComponents.side9, eventBus)
+    }
+}

--- a/content/other/login/build.gradle.kts
+++ b/content/other/login/build.gradle.kts
@@ -7,4 +7,7 @@ dependencies {
     implementation(projects.api.invWeight)
     implementation(projects.api.pluginCommons)
     implementation(projects.api.realm)
+    implementation(projects.api.net)
+    implementation(projects.api.dbGateway)
+    implementation(projects.api.social)
 }

--- a/content/other/login/src/main/kotlin/org/rsmod/content/other/login/LoginScript.kt
+++ b/content/other/login/src/main/kotlin/org/rsmod/content/other/login/LoginScript.kt
@@ -17,6 +17,8 @@ import net.rsprot.protocol.game.outgoing.misc.client.ResetAnims
 import net.rsprot.protocol.game.outgoing.misc.player.ChatFilterSettings
 import net.rsprot.protocol.game.outgoing.varp.VarpReset
 import org.rsmod.api.inv.weight.InvWeight
+import org.rsmod.api.net.central.OpenRuneCentralWorldLink
+import org.rsmod.api.net.central.writeCentralSocialSnapshot
 import org.rsmod.api.player.output.Camera
 import org.rsmod.api.player.output.ChatType
 import org.rsmod.api.player.output.MiscOutput
@@ -47,6 +49,7 @@ constructor(
     private val mapClock: MapClock,
     private val invisibleLevels: InvisibleLevels,
     private val config: ServerConfig,
+    private val central: OpenRuneCentralWorldLink,
 ) : PluginScript() {
     private val transmitVars by lazy { transmitVars() }
 
@@ -64,6 +67,7 @@ constructor(
 
     private fun Player.sendHighPriority() {
         sendChatFilters()
+        sendSocial()
         sendOpVisibility()
         sendWelcomeMessage()
         val validDidYouKnow = DidyouknowRow.all().filter { it.mobileonly != true }.random()
@@ -154,6 +158,25 @@ constructor(
 
     private fun transmitVars(): List<VarpServerType> {
         return ServerCacheManager.getVarps().values.filter { !it.transmit.never }.sortedBy { it.id }
+    }
+
+    private fun Player.sendSocial() {
+        val token = openRuneCentralSessionToken
+
+        if (token == null || characterId <= 0) {
+            mes("Social list did not load: missing Central session.")
+            return
+        }
+
+        when (val result = central.socialSnapshot(token, characterId)) {
+            is OpenRuneCentralWorldLink.CentralSocialSnapshotResult.Ok -> {
+                writeCentralSocialSnapshot(result.snapshot)
+            }
+
+            is OpenRuneCentralWorldLink.CentralSocialSnapshotResult.Failed -> {
+                mes("Social list did not load: ${result.message}")
+            }
+        }
     }
 
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,7 @@ spotless = "7.0.4"
 postgresql-jdbc = "42.7.5"
 embedded-postgres = "2.2.2"
 or2 = "2.4.12"
-openruneCentral = "1.3.1"
+openruneCentral = "1.3.2"
 or2ServerUtils = "0.8"
 jodatime = "2.14.0"
 


### PR DESCRIPTION
Route social features through OpenRune Central

Adds game-server integration for Central-backed social features:
- friends and ignores add/delete handlers
- Central social snapshot loading
- private message send/receive through world-link
- sender crown support for private messages
- private chat filter updates
- live friend presence updates
- login/logout notification messages

Central social only applies the private chat filter. Public and trade
filters remain owned by their respective game systems.

Let me know if you see anything I missed or that needs more work.