### PR TITLE
Deposit Box Interface

### DIFF
--- a/.data/gamevals/category.rscm
+++ b/.data/gamevals/category.rscm
@@ -27,6 +27,7 @@ cooking_fire=152
 regular_cut_tree=189
 runite_rocks=202
 furnace=215
+deposit_box=276
 vampyres=408
 arrows_training=555
 ballista=567

--- a/.data/raw-cache/server/loc.toml
+++ b/.data/raw-cache/server/loc.toml
@@ -1060,46 +1060,6 @@ inherit = "loc.aide_bankbooth"
 contentGroup = "content.bank_booth"
 
 [[object]]
-id = "loc.bank_deposit_box"
-inherit = "loc.bank_deposit_box"
-contentGroup = "content.bank_deposit_box"
-
-[[object]]
-id = "loc.kr_bank_deposit_box"
-inherit = "loc.kr_bank_deposit_box"
-contentGroup = "content.bank_deposit_box"
-
-[[object]]
-id = "loc.swan_bank_deposit_box"
-inherit = "loc.swan_bank_deposit_box"
-contentGroup = "content.bank_deposit_box"
-
-[[object]]
-id = "loc.burgh_bank_deposit_box"
-inherit = "loc.burgh_bank_deposit_box"
-contentGroup = "content.bank_deposit_box"
-
-[[object]]
-id = "loc.ahoy_bank_deposit_box"
-inherit = "loc.ahoy_bank_deposit_box"
-contentGroup = "content.bank_deposit_box"
-
-[[object]]
-id = "loc.corscurs_bank_deposit_box"
-inherit = "loc.corscurs_bank_deposit_box"
-contentGroup = "content.bank_deposit_box"
-
-[[object]]
-id = "loc.bank_deposit_box_2"
-inherit = "loc.bank_deposit_box_2"
-contentGroup = "content.bank_deposit_box"
-
-[[object]]
-id = "loc.conch_grove_bank_deposit_box"
-inherit = "loc.conch_grove_bank_deposit_box"
-contentGroup = "content.bank_deposit_box"
-
-[[object]]
 id = "loc.rustic_fencegate_r"
 inherit = "loc.rustic_fencegate_r"
 contentGroup = "content.closed_right_picketgate"

--- a/.data/raw-cache/server/loc.toml
+++ b/.data/raw-cache/server/loc.toml
@@ -1060,6 +1060,46 @@ inherit = "loc.aide_bankbooth"
 contentGroup = "content.bank_booth"
 
 [[object]]
+id = "loc.bank_deposit_box"
+inherit = "loc.bank_deposit_box"
+contentGroup = "content.bank_deposit_box"
+
+[[object]]
+id = "loc.kr_bank_deposit_box"
+inherit = "loc.kr_bank_deposit_box"
+contentGroup = "content.bank_deposit_box"
+
+[[object]]
+id = "loc.swan_bank_deposit_box"
+inherit = "loc.swan_bank_deposit_box"
+contentGroup = "content.bank_deposit_box"
+
+[[object]]
+id = "loc.burgh_bank_deposit_box"
+inherit = "loc.burgh_bank_deposit_box"
+contentGroup = "content.bank_deposit_box"
+
+[[object]]
+id = "loc.ahoy_bank_deposit_box"
+inherit = "loc.ahoy_bank_deposit_box"
+contentGroup = "content.bank_deposit_box"
+
+[[object]]
+id = "loc.corscurs_bank_deposit_box"
+inherit = "loc.corscurs_bank_deposit_box"
+contentGroup = "content.bank_deposit_box"
+
+[[object]]
+id = "loc.bank_deposit_box_2"
+inherit = "loc.bank_deposit_box_2"
+contentGroup = "content.bank_deposit_box"
+
+[[object]]
+id = "loc.conch_grove_bank_deposit_box"
+inherit = "loc.conch_grove_bank_deposit_box"
+contentGroup = "content.bank_deposit_box"
+
+[[object]]
 id = "loc.rustic_fencegate_r"
 inherit = "loc.rustic_fencegate_r"
 contentGroup = "content.closed_right_picketgate"

--- a/api/player/src/main/kotlin/org/rsmod/api/player/events/interact/LocEvents.kt
+++ b/api/player/src/main/kotlin/org/rsmod/api/player/events/interact/LocEvents.kt
@@ -538,6 +538,41 @@ public class LocUDefaultEvents {
         public val invSlot: Int,
         locContent: Int = type.contentGroup,
     ) : ApEvent(locContent.toLong())
+
+    /**
+     * Fired when _any_ item is used on a loc whose [ObjectServerType.category] matches the
+     * registered category.
+     * @param loc The _base_ loc target of the event.
+     * @param vis The current _visual_ representation of [loc], based on the player's varps. If
+     *   [loc] has a [ObjectServerType.multiLoc], [vis] reflects the resolved variant. Otherwise,
+     *   [vis] is equal to [loc].
+     * @param type The [ObjectServerType] of the [vis] loc.
+     */
+    public class OpCategory(
+        public val loc: BoundLocInfo,
+        public val vis: BoundLocInfo,
+        public val type: ObjectServerType,
+        public val objType: ItemServerType,
+        public val invSlot: Int,
+        category: Int = type.category,
+    ) : OpEvent(category.toLong())
+
+    /**
+     * The approach (`ap`) counterpart to [OpCategory].
+     * @param loc The _base_ loc target of the event.
+     * @param vis The current _visual_ representation of [loc], based on the player's varps. If
+     *   [loc] has a [ObjectServerType.multiLoc], [vis] reflects the resolved variant. Otherwise,
+     *   [vis] is equal to [loc].
+     * @param type The [ObjectServerType] of the [vis] loc.
+     */
+    public class ApCategory(
+        public val loc: BoundLocInfo,
+        public val vis: BoundLocInfo,
+        public val type: ObjectServerType,
+        public val objType: ItemServerType,
+        public val invSlot: Int,
+        category: Int = type.category,
+    ) : ApEvent(category.toLong())
 }
 
 public class LocUCategoryEvents {

--- a/api/player/src/main/kotlin/org/rsmod/api/player/interact/LocUInteractions.kt
+++ b/api/player/src/main/kotlin/org/rsmod/api/player/interact/LocUInteractions.kt
@@ -111,6 +111,13 @@ public class LocUInteractions @Inject private constructor(private val eventBus: 
             return defGroupScript
         }
 
+        if (locType.category >= 0) {
+            val categoryDefaultEvent = LocUDefaultEvents.OpCategory(base, target, locType, objType, invSlot)
+            if (eventBus.contains(categoryDefaultEvent::class.java, categoryDefaultEvent.id)) {
+                return categoryDefaultEvent
+            }
+        }
+
         return null
     }
 
@@ -190,6 +197,13 @@ public class LocUInteractions @Inject private constructor(private val eventBus: 
         val defGroupScript = LocUDefaultEvents.ApContent(base, target, locType, objType, invSlot)
         if (eventBus.contains(defGroupScript::class.java, defGroupScript.id)) {
             return defGroupScript
+        }
+
+        if (locType.category >= 0) {
+            val categoryDefaultEvent = LocUDefaultEvents.ApCategory(base, target, locType, objType, invSlot)
+            if (eventBus.contains(categoryDefaultEvent::class.java, categoryDefaultEvent.id)) {
+                return categoryDefaultEvent
+            }
         }
 
         return null

--- a/api/script/src/main/kotlin/org/rsmod/api/script/LocScriptEventExtensions.kt
+++ b/api/script/src/main/kotlin/org/rsmod/api/script/LocScriptEventExtensions.kt
@@ -199,6 +199,15 @@ public fun ScriptContext.onOpLocU(
     action: suspend ProtectedAccess.(LocUEvents.Op) -> Unit,
 ): Unit = onOpLocU(RSCM.getReverseMapping(RSCMType.LOC, type.id), objType, action)
 
+public fun ScriptContext.onOpLocCategoryU( //Overload to allow any generic item via category based.
+    category: String,
+    action: suspend ProtectedAccess.(LocUDefaultEvents.OpCategory) -> Unit,
+): Unit =
+    onProtectedEvent(
+        category.asRSCM(RSCMType.CATEGORY),
+        action
+    )
+
 public fun ScriptContext.onOpLocCategoryU(
     category: String,
     objType: String,
@@ -351,6 +360,11 @@ public fun ScriptContext.onApContentLocU(
     content: String,
     action: suspend ProtectedAccess.(LocUDefaultEvents.ApContent) -> Unit,
 ): Unit = onProtectedEvent(content.asRSCM(RSCMType.CONTENT), action)
+
+public fun ScriptContext.onApLocCategoryU(
+    category: String,
+    action: suspend ProtectedAccess.(LocUDefaultEvents.ApCategory) -> Unit,
+): Unit = onProtectedEvent(category.asRSCM(RSCMType.CATEGORY), action)
 
 public fun ScriptContext.onApLocU(
     type: String,

--- a/content/interfaces/bank/src/main/kotlin/org/rsmod/content/interfaces/bank/scripts/BankInvScript.kt
+++ b/content/interfaces/bank/src/main/kotlin/org/rsmod/content/interfaces/bank/scripts/BankInvScript.kt
@@ -212,7 +212,7 @@ constructor(
         invDeposit(slot, count, inv)
     }
 
-    private fun ProtectedAccess.invDeposit(slot: Int, count: Int, inventory: Inventory): Boolean {
+    public fun ProtectedAccess.invDeposit(slot: Int, count: Int, inventory: Inventory): Boolean {
         val obj = inventory[slot]
         if (obj == null) {
             resendSlot(inventory, 0)
@@ -330,7 +330,7 @@ constructor(
         }
     }
 
-    private fun ProtectedAccess.depositInv() {
+    public fun ProtectedAccess.depositInv() {
         if (inv.isEmpty()) {
             mes("You have nothing to deposit.")
             return
@@ -338,7 +338,7 @@ constructor(
         depositInventory(inv)
     }
 
-    private fun ProtectedAccess.depositWorn() {
+    public fun ProtectedAccess.depositWorn() {
         if (worn.isEmpty()) {
             mes("You have nothing to deposit.")
             return

--- a/content/interfaces/deposit-box/build.gradle.kts
+++ b/content/interfaces/deposit-box/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    id("base-conventions")
+}
+
+dependencies {
+    implementation(projects.api.pluginCommons)
+    implementation(projects.content.interfaces.bank)
+}

--- a/content/interfaces/deposit-box/src/main/kotlin/org.rsmod.content.interfaces.depositbox/DepositBoxActions.kt
+++ b/content/interfaces/deposit-box/src/main/kotlin/org.rsmod.content.interfaces.depositbox/DepositBoxActions.kt
@@ -1,0 +1,77 @@
+package org.rsmod.content.interfaces.depositbox
+
+import org.rsmod.api.player.protect.ProtectedAccess
+import org.rsmod.api.player.vars.boolVarBit
+import org.rsmod.api.player.vars.intVarBit
+import org.rsmod.api.player.vars.intVarp
+import org.rsmod.content.interfaces.bank.QuantityMode
+import org.rsmod.content.interfaces.depositbox.configs.DepositBoxConfig
+import org.rsmod.content.interfaces.depositbox.configs.deposit_constants
+import org.rsmod.game.entity.Player
+
+private var Player.depositBoxMode by intVarBit("varbit.depositbox_mode")
+private var Player.depositBoxQtyInput by intVarp("varp.depositbox_requestedquantity")
+
+/** "Hide deposit worn items" menu toggle. */
+internal var Player.hideDepositWornButton by boolVarBit("varbit.depositbox_hidedepositworn")
+
+/** Settings toggle (setting 424 in the settings interface): when true, using an item on a
+deposit box will deposit the full stack. Otherwise, it will prompt for the quantity.
+The varbit value appears inverted, so the naming is inverted in code to reflect this.  */
+internal val ProtectedAccess.opLocUDepositAll by boolVarBit("varbit.bank_depositbox_oplocu_askquantity")
+
+
+/** Matches QuantityMode.varValue except swaps the 10 and All values. */
+private fun QuantityMode.toDepositBoxMode(): Int =
+    when (this) {
+        QuantityMode.Ten -> QuantityMode.All.varValue
+        QuantityMode.All -> QuantityMode.Ten.varValue
+        else -> varValue
+    }
+
+/** Inverse of [toDepositBoxMode], with unknown values falling back to One. */
+private fun quantityModeOf(depositBoxMode: Int): QuantityMode =
+    when (depositBoxMode) {
+        QuantityMode.Ten.varValue -> QuantityMode.All
+        QuantityMode.All.varValue -> QuantityMode.Ten
+        else -> QuantityMode.entries.firstOrNull { it.varValue == depositBoxMode } ?: QuantityMode.One
+    }
+
+
+/** Selected quantity button. Writing it persists the selection and updates the client render state. */
+internal var ProtectedAccess.depositQuantityMode: QuantityMode
+    get() = quantityModeOf(player.depositBoxMode)
+    set(value) {
+        player.depositBoxMode = value.toDepositBoxMode()
+    }
+
+/** Custom "X" amount, persisted and mirrored to the client. */
+internal var ProtectedAccess.depositQuantityInput: Int
+    get() = player.depositBoxQtyInput
+    set(value) {
+        player.depositBoxQtyInput = value
+    }
+
+/** Amount option 1 deposits for the current selection. E.g. normally this is the option assigned to left clicks directly on the item */
+internal fun ProtectedAccess.depositOption1Qty(): Int =
+    when (depositQuantityMode) {
+        QuantityMode.One -> 1
+        QuantityMode.Five -> 5
+        QuantityMode.Ten -> 10
+        QuantityMode.X -> maxOf(1, depositQuantityInput)
+        QuantityMode.All -> Int.MAX_VALUE
+    }
+
+internal fun ProtectedAccess.playDepositAnim() {
+    anim(deposit_constants.open_seq)
+}
+
+/** Determines the next slot that should be deposited. Basically used to resolve the action based on the config option DepositBoxConfig.deposit_top_to_bottom */
+internal fun ProtectedAccess.resolveDepositSlot(clickedSlot: Int): Int {
+    if (!DepositBoxConfig.deposit_top_to_bottom) {
+        return clickedSlot
+    }
+    val id = inv[clickedSlot]?.id ?: return clickedSlot
+    val firstSlot = inv.indexOfFirst { it?.id == id }
+    return if (firstSlot != -1) firstSlot else clickedSlot
+}

--- a/content/interfaces/deposit-box/src/main/kotlin/org.rsmod.content.interfaces.depositbox/DepositBoxActions.kt
+++ b/content/interfaces/deposit-box/src/main/kotlin/org.rsmod.content.interfaces.depositbox/DepositBoxActions.kt
@@ -6,7 +6,7 @@ import org.rsmod.api.player.vars.intVarBit
 import org.rsmod.api.player.vars.intVarp
 import org.rsmod.content.interfaces.bank.QuantityMode
 import org.rsmod.content.interfaces.depositbox.configs.DepositBoxConfig
-import org.rsmod.content.interfaces.depositbox.configs.deposit_constants
+import org.rsmod.content.interfaces.depositbox.configs.DepositBoxConstants
 import org.rsmod.game.entity.Player
 
 private var Player.depositBoxMode by intVarBit("varbit.depositbox_mode")
@@ -63,12 +63,12 @@ internal fun ProtectedAccess.depositOption1Qty(): Int =
     }
 
 internal fun ProtectedAccess.playDepositAnim() {
-    anim(deposit_constants.open_seq)
+    anim(DepositBoxConstants.OPEN_SEQ)
 }
 
 /** Determines the next slot that should be deposited. Basically used to resolve the action based on the config option DepositBoxConfig.deposit_top_to_bottom */
 internal fun ProtectedAccess.resolveDepositSlot(clickedSlot: Int): Int {
-    if (!DepositBoxConfig.deposit_top_to_bottom) {
+    if (!DepositBoxConfig.DEPOSIT_TOP_TO_BOTTOM) {
         return clickedSlot
     }
     val id = inv[clickedSlot]?.id ?: return clickedSlot

--- a/content/interfaces/deposit-box/src/main/kotlin/org.rsmod.content.interfaces.depositbox/DepositBoxBank.kt
+++ b/content/interfaces/deposit-box/src/main/kotlin/org.rsmod.content.interfaces.depositbox/DepositBoxBank.kt
@@ -1,0 +1,61 @@
+package org.rsmod.content.interfaces.depositbox
+
+import org.rsmod.api.player.protect.ProtectedAccess
+import org.rsmod.content.interfaces.bank.BankTab
+import org.rsmod.content.interfaces.bank.scripts.BankInvScript
+import org.rsmod.content.interfaces.bank.selectedTab
+import org.rsmod.game.inv.Inventory
+
+/** A deposit box only deposits into the main tab, so each deposit runs with the main tab selected and the player's tab selection in the bank is restored afterward. */
+private inline fun ProtectedAccess.intoMainTab(block: () -> Unit) {
+    val previous = selectedTab
+    if (previous != BankTab.Main) {
+        selectedTab = BankTab.Main
+    }
+    try {
+        block()
+    } finally {
+        if (previous != BankTab.Main) {
+            selectedTab = previous
+        }
+    }
+}
+
+internal fun ProtectedAccess.bankDeposit(
+    bankInv: BankInvScript,
+    slot: Int,
+    count: Int,
+    from: Inventory,
+): Boolean {
+    var deposited = false
+    intoMainTab { deposited = with(bankInv) { this@bankDeposit.invDeposit(slot, count, from) } }
+    return deposited
+}
+
+/** Deposits the whole player inventory and returns whether anything was actually deposited.
+ * Note: I utilize the functions straight from the bank scripts. */
+internal fun ProtectedAccess.bankDepositInv(bankInv: BankInvScript): Boolean {
+    val freeBefore = inv.freeSpace()
+    intoMainTab { with(bankInv) { this@bankDepositInv.depositInv() } }
+    return inv.freeSpace() != freeBefore
+}
+
+internal fun ProtectedAccess.bankDepositWorn(bankInv: BankInvScript): Boolean {
+    val freeBefore = worn.freeSpace()
+    intoMainTab { with(bankInv) { this@bankDepositWorn.depositWorn() } }
+    return worn.freeSpace() != freeBefore
+}
+
+/** Deposits count of the item at clickedSlot using the deposit-ordering config, playing the animation whenever anything is deposited. */
+internal fun ProtectedAccess.depositInventoryItem(
+    bankInv: BankInvScript,
+    clickedSlot: Int,
+    count: Int,
+) {
+    if (inv[clickedSlot] == null || count <= 0) {
+        return
+    }
+    if (bankDeposit(bankInv, resolveDepositSlot(clickedSlot), count, inv)) {
+        playDepositAnim()
+    }
+}

--- a/content/interfaces/deposit-box/src/main/kotlin/org.rsmod.content.interfaces.depositbox/configs/DepositBoxConfig.kt
+++ b/content/interfaces/deposit-box/src/main/kotlin/org.rsmod.content.interfaces.depositbox/configs/DepositBoxConfig.kt
@@ -4,5 +4,5 @@ object DepositBoxConfig {
     // Behavior when the clicked item also exists in other inventory slots. This can probably be extracted into a toml at some point.
     // true  = deposit from the topmost matching slot (left-to-right, top-to-bottom). This is the accurate behavior.
     // false = deposit from the exact slot that was clicked.
-    const val deposit_top_to_bottom: Boolean = true
+    const val DEPOSIT_TOP_TO_BOTTOM: Boolean = true
 }

--- a/content/interfaces/deposit-box/src/main/kotlin/org.rsmod.content.interfaces.depositbox/configs/DepositBoxConfig.kt
+++ b/content/interfaces/deposit-box/src/main/kotlin/org.rsmod.content.interfaces.depositbox/configs/DepositBoxConfig.kt
@@ -1,0 +1,8 @@
+package org.rsmod.content.interfaces.depositbox.configs
+
+object DepositBoxConfig {
+    // Behavior when the clicked item also exists in other inventory slots. This can probably be extracted into a toml at some point.
+    // true  = deposit from the topmost matching slot (left-to-right, top-to-bottom). This is the accurate behavior.
+    // false = deposit from the exact slot that was clicked.
+    const val deposit_top_to_bottom: Boolean = true
+}

--- a/content/interfaces/deposit-box/src/main/kotlin/org.rsmod.content.interfaces.depositbox/configs/DepositBoxConstants.kt
+++ b/content/interfaces/deposit-box/src/main/kotlin/org.rsmod.content.interfaces.depositbox/configs/DepositBoxConstants.kt
@@ -1,0 +1,46 @@
+@file:Suppress("ConstPropertyName")
+
+package org.rsmod.content.interfaces.depositbox.configs
+
+internal typealias deposit_constants = DepositBoxConstants
+
+object DepositBoxConstants {
+    // Content group tagged on deposit box locs.
+    const val content_group = "content.bank_deposit_box"
+
+    // Animation played when depositing.
+    const val open_seq = "seq.human_leverdown"
+
+    // The deposit box modal.
+    const val interface_main = "interface.bank_depositbox"
+
+    // The deposit box's own inventory grid (clicked to deposit).
+    const val comp_items = "component.bank_depositbox:inventory"
+
+    // "Deposit inventory" and "Deposit worn items" buttons.
+    const val comp_deposit_inv = "component.bank_depositbox:deposit_inv"
+    const val comp_deposit_worn = "component.bank_depositbox:deposit_worn"
+
+    // "Hide deposit worn items" checkbox in the top-left menu dropdown.
+    const val comp_depositworn_toggle = "component.bank_depositbox:depositworn_toggle"
+
+    // Quantity selection buttons (1 / 5 / 10 / X / All).
+    const val comp_quantity_1 = "component.bank_depositbox:1"
+    const val comp_quantity_5 = "component.bank_depositbox:5"
+    const val comp_quantity_10 = "component.bank_depositbox:10"
+    const val comp_quantity_x = "component.bank_depositbox:x"
+    const val comp_quantity_all = "component.bank_depositbox:all"
+
+    //TODO: Inventory slot-lock settings button is not implemented.
+    const val comp_lock_menu = "component.bank_depositbox:lock_menu"
+
+    // Wearpos of each equipment slot shown in the box; the per-slot component is "slot<wearpos>".
+    val worn_wearpos_slots = intArrayOf(0, 1, 2, 3, 4, 5, 7, 9, 10, 12, 13)
+
+    fun wornComponent(wearpos: Int): String = "component.bank_depositbox:slot$wearpos"
+
+    // Inventory interfaces we swap to "disable" the inventory when the deposit box interface is open.
+    const val inventory_interface = "interface.inventory"
+    const val inventory_disabled = "interface.inventory_noops"
+    const val inventory_main_target = "component.toplevel_osrs_stretch:side3"
+}

--- a/content/interfaces/deposit-box/src/main/kotlin/org.rsmod.content.interfaces.depositbox/configs/DepositBoxConstants.kt
+++ b/content/interfaces/deposit-box/src/main/kotlin/org.rsmod.content.interfaces.depositbox/configs/DepositBoxConstants.kt
@@ -1,46 +1,40 @@
-@file:Suppress("ConstPropertyName")
-
 package org.rsmod.content.interfaces.depositbox.configs
 
-internal typealias deposit_constants = DepositBoxConstants
-
 object DepositBoxConstants {
-    // Content group tagged on deposit box locs.
-    const val content_group = "content.bank_deposit_box"
 
     // Animation played when depositing.
-    const val open_seq = "seq.human_leverdown"
+    const val OPEN_SEQ = "seq.human_leverdown"
 
     // The deposit box modal.
-    const val interface_main = "interface.bank_depositbox"
+    const val INTERFACE_MAIN = "interface.bank_depositbox"
 
     // The deposit box's own inventory grid (clicked to deposit).
-    const val comp_items = "component.bank_depositbox:inventory"
+    const val COMP_ITEMS = "component.bank_depositbox:inventory"
 
     // "Deposit inventory" and "Deposit worn items" buttons.
-    const val comp_deposit_inv = "component.bank_depositbox:deposit_inv"
-    const val comp_deposit_worn = "component.bank_depositbox:deposit_worn"
+    const val COMP_DEPOSIT_INV = "component.bank_depositbox:deposit_inv"
+    const val COMP_DEPOSIT_WORN = "component.bank_depositbox:deposit_worn"
 
     // "Hide deposit worn items" checkbox in the top-left menu dropdown.
-    const val comp_depositworn_toggle = "component.bank_depositbox:depositworn_toggle"
+    const val COMP_DEPOSITWORN_TOGGLE = "component.bank_depositbox:depositworn_toggle"
 
     // Quantity selection buttons (1 / 5 / 10 / X / All).
-    const val comp_quantity_1 = "component.bank_depositbox:1"
-    const val comp_quantity_5 = "component.bank_depositbox:5"
-    const val comp_quantity_10 = "component.bank_depositbox:10"
-    const val comp_quantity_x = "component.bank_depositbox:x"
-    const val comp_quantity_all = "component.bank_depositbox:all"
+    const val COMP_QUANTITY_1 = "component.bank_depositbox:1"
+    const val COMP_QUANTITY_5 = "component.bank_depositbox:5"
+    const val COMP_QUANTITY_10 = "component.bank_depositbox:10"
+    const val COMP_QUANTITY_X = "component.bank_depositbox:x"
+    const val COMP_QUANTITY_ALL = "component.bank_depositbox:all"
 
     //TODO: Inventory slot-lock settings button is not implemented.
-    const val comp_lock_menu = "component.bank_depositbox:lock_menu"
+    const val COM_LOCK_MENU = "component.bank_depositbox:lock_menu"
 
     // Wearpos of each equipment slot shown in the box; the per-slot component is "slot<wearpos>".
-    val worn_wearpos_slots = intArrayOf(0, 1, 2, 3, 4, 5, 7, 9, 10, 12, 13)
+    val WORN_WEAPOS_SLOTS = intArrayOf(0, 1, 2, 3, 4, 5, 7, 9, 10, 12, 13)
 
     fun wornComponent(wearpos: Int): String = "component.bank_depositbox:slot$wearpos"
 
     // Inventory interfaces we swap to "disable" the inventory when the deposit box interface is open.
-    const val inventory_interface = "interface.inventory"
-    const val inventory_disabled = "interface.inventory_noops"
-    const val inventory_main_target = "component.toplevel_osrs_stretch:side3"
+    const val INVENTORY_INTERFACE = "interface.inventory"
+    const val INVENTORY_DISABLED = "interface.inventory_noops"
+    const val INVENTORY_MAIN_TARGET = "component.toplevel_osrs_stretch:side3"
 }

--- a/content/interfaces/deposit-box/src/main/kotlin/org.rsmod.content.interfaces.depositbox/scripts/DepositBoxInterfaceScript.kt
+++ b/content/interfaces/deposit-box/src/main/kotlin/org.rsmod.content.interfaces.depositbox/scripts/DepositBoxInterfaceScript.kt
@@ -41,9 +41,16 @@ constructor(private val eventBus: EventBus, private val bankInv: BankInvScript) 
         onIfModalButton(deposit_constants.comp_quantity_5) { depositQuantityMode = QuantityMode.Five }
         onIfModalButton(deposit_constants.comp_quantity_10) { depositQuantityMode = QuantityMode.Ten }
         onIfModalButton(deposit_constants.comp_quantity_all) { depositQuantityMode = QuantityMode.All }
+        /* An X input that exactly matches a preset button (1/5/10) selects that button instead */
         onIfModalButton(deposit_constants.comp_quantity_x) {
             val input = countDialog()
-            if (input > 0) {
+            if (input <= 0) {
+                return@onIfModalButton
+            }
+            val preset = presetQuantityMode(input)
+            if (preset != null) {
+                depositQuantityMode = preset
+            } else {
                 depositQuantityInput = input
                 depositQuantityMode = QuantityMode.X
             }
@@ -68,6 +75,15 @@ constructor(private val eventBus: EventBus, private val bankInv: BankInvScript) 
             onIfModalButton(deposit_constants.wornComponent(wearpos)) { wornOp(wearpos, it.op) }
         }
     }
+
+    /** Preset quantity button matching an exact amount, or null if only "X" can represent it. */
+    private fun presetQuantityMode(amount: Int): QuantityMode? =
+        when (amount) {
+            1 -> QuantityMode.One
+            5 -> QuantityMode.Five
+            10 -> QuantityMode.Ten
+            else -> null
+        }
 
     private fun Player.onDepositBoxOpen() {
         setItemEvents()

--- a/content/interfaces/deposit-box/src/main/kotlin/org.rsmod.content.interfaces.depositbox/scripts/DepositBoxInterfaceScript.kt
+++ b/content/interfaces/deposit-box/src/main/kotlin/org.rsmod.content.interfaces.depositbox/scripts/DepositBoxInterfaceScript.kt
@@ -16,7 +16,7 @@ import org.rsmod.content.interfaces.bank.QuantityMode
 import org.rsmod.content.interfaces.bank.scripts.BankInvScript
 import org.rsmod.content.interfaces.depositbox.bankDepositInv
 import org.rsmod.content.interfaces.depositbox.bankDepositWorn
-import org.rsmod.content.interfaces.depositbox.configs.deposit_constants
+import org.rsmod.content.interfaces.depositbox.configs.DepositBoxConstants
 import org.rsmod.content.interfaces.depositbox.depositInventoryItem
 import org.rsmod.content.interfaces.depositbox.depositOption1Qty
 import org.rsmod.content.interfaces.depositbox.depositQuantityInput
@@ -32,17 +32,17 @@ class DepositBoxInterfaceScript
 @Inject
 constructor(private val eventBus: EventBus, private val bankInv: BankInvScript) : PluginScript() {
     override fun ScriptContext.startup() {
-        onIfOpen(deposit_constants.interface_main) { player.onDepositBoxOpen() }
-        onIfClose(deposit_constants.interface_main) { player.onDepositBoxClose() }
+        onIfOpen(DepositBoxConstants.INTERFACE_MAIN) { player.onDepositBoxOpen() }
+        onIfClose(DepositBoxConstants.INTERFACE_MAIN) { player.onDepositBoxClose() }
 
-        onIfModalButton(deposit_constants.comp_items) { itemOp(it.comsub, it.op) }
+        onIfModalButton(DepositBoxConstants.COMP_ITEMS) { itemOp(it.comsub, it.op) }
 
-        onIfModalButton(deposit_constants.comp_quantity_1) { depositQuantityMode = QuantityMode.One }
-        onIfModalButton(deposit_constants.comp_quantity_5) { depositQuantityMode = QuantityMode.Five }
-        onIfModalButton(deposit_constants.comp_quantity_10) { depositQuantityMode = QuantityMode.Ten }
-        onIfModalButton(deposit_constants.comp_quantity_all) { depositQuantityMode = QuantityMode.All }
+        onIfModalButton(DepositBoxConstants.COMP_QUANTITY_1) { depositQuantityMode = QuantityMode.One }
+        onIfModalButton(DepositBoxConstants.COMP_QUANTITY_5) { depositQuantityMode = QuantityMode.Five }
+        onIfModalButton(DepositBoxConstants.COMP_QUANTITY_10) { depositQuantityMode = QuantityMode.Ten }
+        onIfModalButton(DepositBoxConstants.COMP_QUANTITY_ALL) { depositQuantityMode = QuantityMode.All }
         /* An X input that exactly matches a preset button (1/5/10) selects that button instead */
-        onIfModalButton(deposit_constants.comp_quantity_x) {
+        onIfModalButton(DepositBoxConstants.COMP_QUANTITY_X) {
             val input = countDialog()
             if (input <= 0) {
                 return@onIfModalButton
@@ -56,23 +56,23 @@ constructor(private val eventBus: EventBus, private val bankInv: BankInvScript) 
             }
         }
 
-        onIfModalButton(deposit_constants.comp_deposit_inv) {
+        onIfModalButton(DepositBoxConstants.COMP_DEPOSIT_INV) {
             if (bankDepositInv(bankInv)) {
                 playDepositAnim()
             }
         }
-        onIfModalButton(deposit_constants.comp_deposit_worn) {
+        onIfModalButton(DepositBoxConstants.COMP_DEPOSIT_WORN) {
             if (bankDepositWorn(bankInv)) {
                 playDepositAnim()
             }
         }
 
-        onIfModalButton(deposit_constants.comp_depositworn_toggle) {
+        onIfModalButton(DepositBoxConstants.COMP_DEPOSITWORN_TOGGLE) {
             player.hideDepositWornButton = !player.hideDepositWornButton
         }
 
-        for (wearpos in deposit_constants.worn_wearpos_slots) {
-            onIfModalButton(deposit_constants.wornComponent(wearpos)) { wornOp(wearpos, it.op) }
+        for (wearpos in DepositBoxConstants.WORN_WEAPOS_SLOTS) {
+            onIfModalButton(DepositBoxConstants.wornComponent(wearpos)) { wornOp(wearpos, it.op) }
         }
     }
 
@@ -97,7 +97,7 @@ constructor(private val eventBus: EventBus, private val bankInv: BankInvScript) 
     /** Item options are drawn dynamically by the cache (`bank_depositbox_drawslot`). op1 becomes the selected quantity. */
     private fun Player.setItemEvents() {
         ifSetEvents(
-            deposit_constants.comp_items,
+            DepositBoxConstants.COMP_ITEMS,
             inv.indices,
             IfEvent.Op1,
             IfEvent.Op2,
@@ -150,10 +150,10 @@ constructor(private val eventBus: EventBus, private val bankInv: BankInvScript) 
     /** The box has its own inventory grid, so the real inventory is swapped to the no-ops variant (to gray things out).
      * It's an overlay swap (not a modal), so the other side-panel tabs stay usable since that's the accurate behavior. */
     private fun Player.disableMainInventory() {
-        ifCloseOverlay(deposit_constants.inventory_interface, eventBus)
+        ifCloseOverlay(DepositBoxConstants.INVENTORY_INTERFACE, eventBus)
         ifOpenSub(
-            deposit_constants.inventory_disabled,
-            deposit_constants.inventory_main_target,
+            DepositBoxConstants.INVENTORY_DISABLED,
+            DepositBoxConstants.INVENTORY_MAIN_TARGET,
             IfSubType.Overlay,
             eventBus,
         )
@@ -161,10 +161,10 @@ constructor(private val eventBus: EventBus, private val bankInv: BankInvScript) 
 
     /** Swaps the normal inventory back in, which re-runs the standard inventory open (restoring its events and draw).*/
     private fun Player.enableMainInventory() {
-        ifCloseOverlay(deposit_constants.inventory_disabled, eventBus)
+        ifCloseOverlay(DepositBoxConstants.INVENTORY_DISABLED, eventBus)
         ifOpenSub(
-            deposit_constants.inventory_interface,
-            deposit_constants.inventory_main_target,
+            DepositBoxConstants.INVENTORY_INTERFACE,
+            DepositBoxConstants.INVENTORY_MAIN_TARGET,
             IfSubType.Overlay,
             eventBus,
         )

--- a/content/interfaces/deposit-box/src/main/kotlin/org.rsmod.content.interfaces.depositbox/scripts/DepositBoxInterfaceScript.kt
+++ b/content/interfaces/deposit-box/src/main/kotlin/org.rsmod.content.interfaces.depositbox/scripts/DepositBoxInterfaceScript.kt
@@ -1,0 +1,156 @@
+package org.rsmod.content.interfaces.depositbox.scripts
+
+import dev.openrune.definition.type.widget.IfEvent
+import dev.openrune.types.aconverted.interf.IfButtonOp
+import dev.openrune.types.aconverted.interf.IfSubType
+import jakarta.inject.Inject
+import org.rsmod.api.player.protect.ProtectedAccess
+import org.rsmod.api.player.ui.ifCloseOverlay
+import org.rsmod.api.player.ui.ifOpenSub
+import org.rsmod.api.player.ui.ifSetEvents
+import org.rsmod.api.player.worn.WornUnequipResult
+import org.rsmod.api.script.onIfClose
+import org.rsmod.api.script.onIfModalButton
+import org.rsmod.api.script.onIfOpen
+import org.rsmod.content.interfaces.bank.QuantityMode
+import org.rsmod.content.interfaces.bank.scripts.BankInvScript
+import org.rsmod.content.interfaces.depositbox.bankDepositInv
+import org.rsmod.content.interfaces.depositbox.bankDepositWorn
+import org.rsmod.content.interfaces.depositbox.configs.deposit_constants
+import org.rsmod.content.interfaces.depositbox.depositInventoryItem
+import org.rsmod.content.interfaces.depositbox.depositOption1Qty
+import org.rsmod.content.interfaces.depositbox.depositQuantityInput
+import org.rsmod.content.interfaces.depositbox.depositQuantityMode
+import org.rsmod.content.interfaces.depositbox.hideDepositWornButton
+import org.rsmod.content.interfaces.depositbox.playDepositAnim
+import org.rsmod.events.EventBus
+import org.rsmod.game.entity.Player
+import org.rsmod.plugin.scripts.PluginScript
+import org.rsmod.plugin.scripts.ScriptContext
+
+class DepositBoxInterfaceScript
+@Inject
+constructor(private val eventBus: EventBus, private val bankInv: BankInvScript) : PluginScript() {
+    override fun ScriptContext.startup() {
+        onIfOpen(deposit_constants.interface_main) { player.onDepositBoxOpen() }
+        onIfClose(deposit_constants.interface_main) { player.onDepositBoxClose() }
+
+        onIfModalButton(deposit_constants.comp_items) { itemOp(it.comsub, it.op) }
+
+        onIfModalButton(deposit_constants.comp_quantity_1) { depositQuantityMode = QuantityMode.One }
+        onIfModalButton(deposit_constants.comp_quantity_5) { depositQuantityMode = QuantityMode.Five }
+        onIfModalButton(deposit_constants.comp_quantity_10) { depositQuantityMode = QuantityMode.Ten }
+        onIfModalButton(deposit_constants.comp_quantity_all) { depositQuantityMode = QuantityMode.All }
+        onIfModalButton(deposit_constants.comp_quantity_x) {
+            val input = countDialog()
+            if (input > 0) {
+                depositQuantityInput = input
+                depositQuantityMode = QuantityMode.X
+            }
+        }
+
+        onIfModalButton(deposit_constants.comp_deposit_inv) {
+            if (bankDepositInv(bankInv)) {
+                playDepositAnim()
+            }
+        }
+        onIfModalButton(deposit_constants.comp_deposit_worn) {
+            if (bankDepositWorn(bankInv)) {
+                playDepositAnim()
+            }
+        }
+
+        onIfModalButton(deposit_constants.comp_depositworn_toggle) {
+            player.hideDepositWornButton = !player.hideDepositWornButton
+        }
+
+        for (wearpos in deposit_constants.worn_wearpos_slots) {
+            onIfModalButton(deposit_constants.wornComponent(wearpos)) { wornOp(wearpos, it.op) }
+        }
+    }
+
+    private fun Player.onDepositBoxOpen() {
+        setItemEvents()
+        disableMainInventory()
+    }
+
+    private fun Player.onDepositBoxClose() {
+        enableMainInventory()
+    }
+
+    /** Item options are drawn dynamically by the cache (`bank_depositbox_drawslot`). op1 becomes the selected quantity. */
+    private fun Player.setItemEvents() {
+        ifSetEvents(
+            deposit_constants.comp_items,
+            inv.indices,
+            IfEvent.Op1,
+            IfEvent.Op2,
+            IfEvent.Op3,
+            IfEvent.Op4,
+            IfEvent.Op5,
+            IfEvent.Op6,
+            IfEvent.Op10,
+            IfEvent.Depth1,
+        )
+    }
+
+    /** op1 = selected quantity (mirrors the left-click), op2-4 = 1/5/10, op5 = X prompt, op6 = All, op10 = Examine. */
+    private suspend fun ProtectedAccess.itemOp(slot: Int, op: IfButtonOp) {
+        if (inv[slot] == null) {
+            return
+        }
+        when (op) {
+            IfButtonOp.Op1 -> depositInventoryItem(bankInv, slot, depositOption1Qty())
+            IfButtonOp.Op2 -> depositInventoryItem(bankInv, slot, 1)
+            IfButtonOp.Op3 -> depositInventoryItem(bankInv, slot, 5)
+            IfButtonOp.Op4 -> depositInventoryItem(bankInv, slot, 10)
+            IfButtonOp.Op5 -> { //x quantity
+                val input = countDialog()
+                if (input > 0) {
+                    depositInventoryItem(bankInv, slot, input)
+                }
+            }
+            IfButtonOp.Op6 -> depositInventoryItem(bankInv, slot, Int.MAX_VALUE)
+            IfButtonOp.Op10 -> objExamine(inv, slot)
+            else -> {}
+        }
+    }
+
+    /** Clicking a worn item unequips it into the inventory rather than depositing it. */
+    private fun ProtectedAccess.wornOp(wornSlot: Int, op: IfButtonOp) {
+        if (op == IfButtonOp.Op10) {
+            objExamine(worn, wornSlot)
+            return
+        }
+        if (worn[wornSlot] == null) {
+            return
+        }
+        val result = wornUnequip(wornSlot)
+        if (result is WornUnequipResult.Fail) {
+            result.message?.let { mes(it) }
+        }
+    }
+
+    /** The box has its own inventory grid, so the real inventory is swapped to the no-ops variant (to gray things out).
+     * It's an overlay swap (not a modal), so the other side-panel tabs stay usable since that's the accurate behavior. */
+    private fun Player.disableMainInventory() {
+        ifCloseOverlay(deposit_constants.inventory_interface, eventBus)
+        ifOpenSub(
+            deposit_constants.inventory_disabled,
+            deposit_constants.inventory_main_target,
+            IfSubType.Overlay,
+            eventBus,
+        )
+    }
+
+    /** Swaps the normal inventory back in, which re-runs the standard inventory open (restoring its events and draw).*/
+    private fun Player.enableMainInventory() {
+        ifCloseOverlay(deposit_constants.inventory_disabled, eventBus)
+        ifOpenSub(
+            deposit_constants.inventory_interface,
+            deposit_constants.inventory_main_target,
+            IfSubType.Overlay,
+            eventBus,
+        )
+    }
+}

--- a/content/interfaces/deposit-box/src/main/kotlin/org.rsmod.content.interfaces.depositbox/scripts/DepositBoxScript.kt
+++ b/content/interfaces/deposit-box/src/main/kotlin/org.rsmod.content.interfaces.depositbox/scripts/DepositBoxScript.kt
@@ -1,0 +1,43 @@
+package org.rsmod.content.interfaces.depositbox.scripts
+
+import jakarta.inject.Inject
+import org.rsmod.api.player.events.interact.LocUDefaultEvents
+import org.rsmod.api.player.protect.ProtectedAccess
+import org.rsmod.api.player.ui.ifOpenMainModal
+import org.rsmod.api.script.onOpContentLoc1
+import org.rsmod.api.script.onOpContentLocU
+import org.rsmod.content.interfaces.bank.scripts.BankInvScript
+import org.rsmod.content.interfaces.depositbox.configs.deposit_constants
+import org.rsmod.content.interfaces.depositbox.depositInventoryItem
+import org.rsmod.content.interfaces.depositbox.opLocUDepositAll
+import org.rsmod.events.EventBus
+import org.rsmod.plugin.scripts.PluginScript
+import org.rsmod.plugin.scripts.ScriptContext
+
+class DepositBoxScript
+@Inject
+constructor(private val eventBus: EventBus, private val bankInv: BankInvScript) : PluginScript() {
+    override fun ScriptContext.startup() {
+        onOpContentLoc1(deposit_constants.content_group) { openDepositBox() }
+        onOpContentLocU(deposit_constants.content_group) { depositUsedItem(it) }
+    }
+
+    private suspend fun ProtectedAccess.openDepositBox() {
+        arriveDelay()
+        player.ifOpenMainModal(deposit_constants.interface_main, eventBus)
+    }
+
+    /** Code that runs when using an item on the deposit box. */
+    private suspend fun ProtectedAccess.depositUsedItem(op: LocUDefaultEvents.OpContent) {
+        arriveDelay()
+        if (opLocUDepositAll) {
+            depositInventoryItem(bankInv, op.invSlot, Int.MAX_VALUE)
+            return
+        }
+        val amount = countDialog()
+        if (amount <= 0) {
+            return
+        }
+        depositInventoryItem(bankInv, op.invSlot, amount)
+    }
+}

--- a/content/interfaces/deposit-box/src/main/kotlin/org.rsmod.content.interfaces.depositbox/scripts/DepositBoxScript.kt
+++ b/content/interfaces/deposit-box/src/main/kotlin/org.rsmod.content.interfaces.depositbox/scripts/DepositBoxScript.kt
@@ -1,13 +1,12 @@
 package org.rsmod.content.interfaces.depositbox.scripts
 
 import jakarta.inject.Inject
-import org.rsmod.api.player.events.interact.LocUDefaultEvents
 import org.rsmod.api.player.protect.ProtectedAccess
 import org.rsmod.api.player.ui.ifOpenMainModal
-import org.rsmod.api.script.onOpContentLoc1
-import org.rsmod.api.script.onOpContentLocU
+import org.rsmod.api.script.onOpLocCategory1
+import org.rsmod.api.script.onOpLocCategoryU
 import org.rsmod.content.interfaces.bank.scripts.BankInvScript
-import org.rsmod.content.interfaces.depositbox.configs.deposit_constants
+import org.rsmod.content.interfaces.depositbox.configs.DepositBoxConstants
 import org.rsmod.content.interfaces.depositbox.depositInventoryItem
 import org.rsmod.content.interfaces.depositbox.opLocUDepositAll
 import org.rsmod.events.EventBus
@@ -18,26 +17,28 @@ class DepositBoxScript
 @Inject
 constructor(private val eventBus: EventBus, private val bankInv: BankInvScript) : PluginScript() {
     override fun ScriptContext.startup() {
-        onOpContentLoc1(deposit_constants.content_group) { openDepositBox() }
-        onOpContentLocU(deposit_constants.content_group) { depositUsedItem(it) }
+
+        //handlers by category. This associates category 276 objects to the deposit box code so we don't have to revisit the loc.toml.
+        onOpLocCategory1("category.deposit_box") { openDepositBox() }
+        onOpLocCategoryU("category.deposit_box") { depositUsedItem(it.invSlot) }
     }
 
     private suspend fun ProtectedAccess.openDepositBox() {
         arriveDelay()
-        player.ifOpenMainModal(deposit_constants.interface_main, eventBus)
+        player.ifOpenMainModal(DepositBoxConstants.INTERFACE_MAIN, eventBus)
     }
 
     /** Code that runs when using an item on the deposit box. */
-    private suspend fun ProtectedAccess.depositUsedItem(op: LocUDefaultEvents.OpContent) {
+    private suspend fun ProtectedAccess.depositUsedItem(invSlot: Int) {
         arriveDelay()
         if (opLocUDepositAll) {
-            depositInventoryItem(bankInv, op.invSlot, Int.MAX_VALUE)
+            depositInventoryItem(bankInv, invSlot, Int.MAX_VALUE)
             return
         }
         val amount = countDialog()
         if (amount <= 0) {
             return
         }
-        depositInventoryItem(bankInv, op.invSlot, amount)
+        depositInventoryItem(bankInv, invSlot, amount)
     }
 }


### PR DESCRIPTION
+ Adds the use of Deposit Boxes and their interface.
+ Modified a few bank functions to be public so I can route through those for deposits.

The lock menu for locking inventory slots remains unimplemented. It wasn't implemented in the bank interface either, and I spent some time on it but couldn't quite figure out how that interface is constructed on the client side.

<img width="538" height="397" alt="image" src="https://github.com/user-attachments/assets/529800ab-c000-4874-85cb-e94521f6143a" />
