### PR TITLE
Enable placeholders for bank interfaces

### DIFF
--- a/.data/raw-cache/server/inv.toml
+++ b/.data/raw-cache/server/inv.toml
@@ -24,7 +24,7 @@ inherit = "inv.bank"
 scope = "Perm"
 stack = "Always"
 protect = false
-placeholders = false
+placeholders = true
 
 [[inventory]]
 isServerOnly = true


### PR DESCRIPTION
Every inventory in the game goes through the same Transaction.insert code path. This flag tells the engine whether it's worth checking "does a placeholder for this item already exist in here, and should I overwrite it?" on every insert.