### PR TITLE
fix: shops always fail to buy items — counting wrong inventory for coins

### DIFF
--- a/api/shops/src/main/kotlin/org/rsmod/api/shops/operation/StandardGpShopOperations.kt
+++ b/api/shops/src/main/kotlin/org/rsmod/api/shops/operation/StandardGpShopOperations.kt
@@ -69,9 +69,10 @@ constructor(
 
 
         val internalName = RSCM.getReverseMapping(RSCMType.OBJ, objType.id)
+        val currencyInternalName = RSCM.getReverseMapping(RSCMType.OBJ, currencyObj.id)
 
         val shopInitialObjCount = shopInv.initialStockCount(obj)
-        val availableCurrencyCount = sideInv.count(internalName)
+        val availableCurrencyCount = sideInv.count(currencyInternalName)
         val cappedRequest =
             if (objType.isStackable) {
                 min(Int.MAX_VALUE - sideInv.count(internalName), initialPurchaseRequest)


### PR DESCRIPTION
`availableCurrencyCount` was counting how many of the purchased item the player already owned, not how many coins they had. Buying anything you didn't already own always failed silently.