### PR TITLE
Small Fixes

### DIFF
--- a/api/player/src/main/kotlin/org/rsmod/api/player/dialogue/align/TextAlignment.kt
+++ b/api/player/src/main/kotlin/org/rsmod/api/player/dialogue/align/TextAlignment.kt
@@ -69,7 +69,9 @@ public class TextAlignment @Inject constructor() {
             if (char == '>' && tagStart != -1) {
                 val tag = text.substring(tagStart + 1, index)
                 tagStart = -1
-                lineBuilder.append('<').append(tag).append('>')
+                if (tag != "br") {
+                    lineBuilder.append('<').append(tag).append('>')
+                }
                 when (tag) {
                     "br" -> {
                         lineBuffer[lineCount] = lineBuilder.substring(lineStart)

--- a/content/interfaces/deposit-box/src/main/kotlin/org.rsmod.content.interfaces.depositbox/DepositBoxActions.kt
+++ b/content/interfaces/deposit-box/src/main/kotlin/org.rsmod.content.interfaces.depositbox/DepositBoxActions.kt
@@ -1,9 +1,11 @@
 package org.rsmod.content.interfaces.depositbox
 
+import dev.openrune.ServerCacheManager
 import org.rsmod.api.player.protect.ProtectedAccess
 import org.rsmod.api.player.vars.boolVarBit
 import org.rsmod.api.player.vars.intVarBit
 import org.rsmod.api.player.vars.intVarp
+import org.rsmod.api.utils.format.formatAmount
 import org.rsmod.content.interfaces.bank.QuantityMode
 import org.rsmod.content.interfaces.depositbox.configs.DepositBoxConfig
 import org.rsmod.content.interfaces.depositbox.configs.DepositBoxConstants
@@ -61,6 +63,42 @@ internal fun ProtectedAccess.depositOption1Qty(): Int =
         QuantityMode.X -> maxOf(1, depositQuantityInput)
         QuantityMode.All -> Int.MAX_VALUE
     }
+
+internal fun ProtectedAccess.heldDepositCount(slot: Int): Int {
+    val obj = inv[slot] ?: return 0
+    val objType = ServerCacheManager.getItem(obj.id) ?: return 0
+    return inv.count(obj, objType)
+}
+
+internal suspend fun ProtectedAccess.requestDepositQuantity(count: Int): Int {
+    if (count == 1) {
+        return 1
+    }
+    val amount = when {
+        count > 10 -> choice5(
+            "1", 1,
+            "5", 5,
+            "10", 10,
+            "X", null,
+            "All", Int.MAX_VALUE,
+            title = "How many would you like to deposit?",
+        )
+        count > 5 -> choice4(
+            "1", 1,
+            "5", 5,
+            "X", null,
+            "All", Int.MAX_VALUE,
+            title = "How many would you like to deposit?",
+        )
+        else -> choice3(
+            "1", 1,
+            "X", null,
+            "All", Int.MAX_VALUE,
+            title = "How many would you like to deposit?",
+        )
+    }
+    return amount ?: countDialog("How many would you like to deposit? 1 - ${count.formatAmount}")
+}
 
 internal fun ProtectedAccess.playDepositAnim() {
     anim(DepositBoxConstants.OPEN_SEQ)

--- a/content/interfaces/deposit-box/src/main/kotlin/org.rsmod.content.interfaces.depositbox/scripts/DepositBoxScript.kt
+++ b/content/interfaces/deposit-box/src/main/kotlin/org.rsmod.content.interfaces.depositbox/scripts/DepositBoxScript.kt
@@ -9,7 +9,9 @@ import org.rsmod.api.script.onOpLocCategoryU
 import org.rsmod.content.interfaces.bank.scripts.BankInvScript
 import org.rsmod.content.interfaces.depositbox.configs.DepositBoxConstants
 import org.rsmod.content.interfaces.depositbox.depositInventoryItem
+import org.rsmod.content.interfaces.depositbox.heldDepositCount
 import org.rsmod.content.interfaces.depositbox.opLocUDepositAll
+import org.rsmod.content.interfaces.depositbox.requestDepositQuantity
 import org.rsmod.events.EventBus
 import org.rsmod.plugin.scripts.PluginScript
 import org.rsmod.plugin.scripts.ScriptContext
@@ -42,7 +44,11 @@ constructor(private val eventBus: EventBus, private val bankInv: BankInvScript) 
             depositInventoryItem(bankInv, invSlot, Int.MAX_VALUE)
             return
         }
-        val amount = countDialog()
+        val count = heldDepositCount(invSlot)
+        if (count <= 0) {
+            return
+        }
+        val amount = requestDepositQuantity(count)
         if (amount <= 0) {
             return
         }

--- a/content/skills/firemaking/src/main/kotlin/org/rsmod/content/skills/firemaking/BurnLogEvents.kt
+++ b/content/skills/firemaking/src/main/kotlin/org/rsmod/content/skills/firemaking/BurnLogEvents.kt
@@ -116,7 +116,7 @@ public class BurnLogEvents @Inject constructor(
             BurnMethod.Bow -> (log.statReq.first().t1 + 20).coerceAtMost(99)
         }
         if (player.firemakingLvl < reqLevel) {
-            player.mes("You need a Firemaking level of $reqLevel to burn ${log.input.name} logs this way.")
+            player.mes("You need a Firemaking level of $reqLevel to burn ${log.input.name} this way.")
             return false
         }
 

--- a/content/skills/firemaking/src/main/kotlin/org/rsmod/content/skills/firemaking/CampfireEvents.kt
+++ b/content/skills/firemaking/src/main/kotlin/org/rsmod/content/skills/firemaking/CampfireEvents.kt
@@ -172,7 +172,7 @@ class CampfireEvents @Inject constructor(
 
     private fun ProtectedAccess.hasFiremakingLevelOrMes(log: FiremakingLogsRow): Boolean {
         if (player.firemakingLvl >= log.statReq.first().t1) return true
-        player.mes("You need a Firemaking level of ${log.statReq.first().t1} to burn ${log.input.name} logs.")
+        player.mes("You need a Firemaking level of ${log.statReq.first().t1} to burn ${log.input.name}.")
         return false
     }
 

--- a/or-cache/src/main/kotlin/dev/openrune/util/TextAlignment.kt
+++ b/or-cache/src/main/kotlin/dev/openrune/util/TextAlignment.kt
@@ -70,7 +70,9 @@ object TextAlignment {
             if (char == '>' && tagStart != -1) {
                 val tag = text.substring(tagStart + 1, index)
                 tagStart = -1
-                lineBuilder.append('<').append(tag).append('>')
+                if (tag != "br") {
+                    lineBuilder.append('<').append(tag).append('>')
+                }
                 when (tag) {
                     "br" -> {
                         lineBuffer[lineCount] = lineBuilder.substring(lineStart)


### PR DESCRIPTION
Some fixes to issues I found while working on crafting:

+ Using an item on Deposit Box now behaves accurately.
+ Fix \<br\> being double counted in some cases (Referenced by #146 ).
+ Fix the extra "log" when burning logs. The item name already had it, so it was appearing twice in the spam message.
