### PR TITLE
Add Draynor Small Net fishing MVP

### DIFF
--- a/.data/gamevals/content.rscm
+++ b/.data/gamevals/content.rscm
@@ -49,3 +49,5 @@ cooking_range_standard=48
 cooking_range_lumbridge=49
 cooking_range_hosidius=50
 chest=51
+fishing_spot=54
+fishing_net=55

--- a/.data/raw-cache/server/items.toml
+++ b/.data/raw-cache/server/items.toml
@@ -52761,3 +52761,8 @@ cost = 50
 examine = "A sky full of stars... and one might change your journey."
 [item.params]
 "param.shop_sale_restricted"=1
+
+[[item]]
+id = "obj.net"
+inherit = "obj.net"
+contentGroup = "content.fishing_net"

--- a/.data/raw-cache/server/npcs.toml
+++ b/.data/raw-cache/server/npcs.toml
@@ -12,6 +12,13 @@ wanderRange = 0
 respawnRate = 50
 
 [[npc]]
+id = "npc.0_48_50_saltfish"
+inherit = "npc.0_48_50_saltfish"
+moveRestrict = "NoMove"
+wanderRange = 0
+contentGroup = "content.fishing_spot"
+
+[[npc]]
 id = "npc.imp"
 inherit = "npc.imp"
 giveChase = false

--- a/api/player/src/main/kotlin/org/rsmod/api/player/events/skilling/SkillingProductSource.kt
+++ b/api/player/src/main/kotlin/org/rsmod/api/player/events/skilling/SkillingProductSource.kt
@@ -1,17 +1,23 @@
-package org.rsmod.api.player.events.skilling
-
-import dev.openrune.types.ItemServerType
-import org.rsmod.api.table.mining.MiningRocksRow
-import org.rsmod.game.loc.BoundLocInfo
-
-public sealed class SkillingProductSource {
-    public data class Mining(
-        public val rock: BoundLocInfo,
-        public val rockData: MiningRocksRow,
-    ) : SkillingProductSource()
-
-    public data class Woodcutting(
-        public val tree: BoundLocInfo,
-        public val productType: ItemServerType,
-    ) : SkillingProductSource()
-}
+package org.rsmod.api.player.events.skilling
+
+import dev.openrune.types.ItemServerType
+import org.rsmod.api.table.mining.MiningRocksRow
+import org.rsmod.game.entity.Npc
+import org.rsmod.game.loc.BoundLocInfo
+
+public sealed class SkillingProductSource {
+    public data class Mining(
+        public val rock: BoundLocInfo,
+        public val rockData: MiningRocksRow,
+    ) : SkillingProductSource()
+
+    public data class Woodcutting(
+        public val tree: BoundLocInfo,
+        public val productType: ItemServerType,
+    ) : SkillingProductSource()
+
+    public data class Fishing(
+        public val npc: Npc,
+        public val productItem: String,
+    ) : SkillingProductSource()
+}

--- a/content/skills/fishing/build.gradle.kts
+++ b/content/skills/fishing/build.gradle.kts
@@ -1,3 +1,7 @@
 plugins {
     id("base-conventions")
 }
+
+dependencies {
+    implementation(projects.api.pluginCommons)
+}

--- a/content/skills/fishing/src/main/kotlin/org/rsmod/content/skills/fishing/configs/FishingRates.kt
+++ b/content/skills/fishing/src/main/kotlin/org/rsmod/content/skills/fishing/configs/FishingRates.kt
@@ -1,0 +1,55 @@
+package org.rsmod.content.skills.fishing.configs
+
+/**
+ * MVP Draynor small-net fishing rates.
+ *
+ * Success rates use Mining-style low/high integers for [org.rsmod.api.player.stat.statRandom].
+ * XP values are whole OSRS XP (shrimp 10, anchovies 40) — same convention as
+ * [org.rsmod.content.skills.mining.configs.miningXp] / woodcutting after fine÷10.
+ *
+ * Catch choice at 15+: on a successful roll, if fishing level ≥ 15, pick shrimp or anchovies
+ * with equal weight. Below 15, shrimp only. (Not separate success tables.)
+ */
+object FishingRates {
+    const val NET_ANIM = "seq.human_smallnet"
+    const val NET_OBJ = "obj.net"
+    const val ACTION_DELAY = 5
+
+    val shrimp =
+        FishCatch(
+            item = "obj.raw_shrimp",
+            level = 1,
+            xp = 10.0,
+            successLow = 24,
+            successHigh = 96,
+        )
+
+    val anchovies =
+        FishCatch(
+            item = "obj.raw_anchovies",
+            level = 15,
+            xp = 40.0,
+            successLow = 24,
+            successHigh = 96,
+        )
+
+    /** Spot success uses shrimp rates for the shared small-net roll. */
+    fun spotSuccessRates(): Pair<Int, Int> = shrimp.successLow to shrimp.successHigh
+
+    fun resolveCatch(fishingLevel: Int, rollAnchovies: Boolean): FishCatch {
+        if (fishingLevel >= anchovies.level && rollAnchovies) {
+            return anchovies
+        }
+        return shrimp
+    }
+
+    fun canFish(fishingLevel: Int): Boolean = fishingLevel >= shrimp.level
+}
+
+data class FishCatch(
+    val item: String,
+    val level: Int,
+    val xp: Double,
+    val successLow: Int,
+    val successHigh: Int,
+)

--- a/content/skills/fishing/src/main/kotlin/org/rsmod/content/skills/fishing/scripts/Fishing.kt
+++ b/content/skills/fishing/src/main/kotlin/org/rsmod/content/skills/fishing/scripts/Fishing.kt
@@ -1,0 +1,127 @@
+package org.rsmod.content.skills.fishing.scripts
+
+import jakarta.inject.Inject
+import org.rsmod.api.player.events.skilling.SkillingProduct
+import org.rsmod.api.player.events.skilling.SkillingProductSource
+import org.rsmod.api.player.protect.ProtectedAccess
+import org.rsmod.api.player.skilling.SkillingAwardResult
+import org.rsmod.api.player.skilling.awardSkillingProduct
+import org.rsmod.api.player.stat.fishingLvl
+import org.rsmod.api.script.onOpContentNpc1
+import org.rsmod.api.script.onOpContentNpcU
+import org.rsmod.api.stats.levelmod.InvisibleLevels
+import org.rsmod.api.stats.xpmod.XpModifiers
+import org.rsmod.content.skills.fishing.configs.FishCatch
+import org.rsmod.content.skills.fishing.configs.FishingRates
+import org.rsmod.game.MapClock
+import org.rsmod.game.entity.Npc
+import org.rsmod.game.inv.InvObj
+import org.rsmod.game.type.getInvObj
+import org.rsmod.plugin.scripts.PluginScript
+import org.rsmod.plugin.scripts.ScriptContext
+
+/**
+ * MVP Small Net fishing (Draynor `npc.0_48_50_saltfish` and any NPC tagged
+ * `content.fishing_spot`).
+ *
+ * Spots do not deplete. Bait/lure and other tools are out of scope.
+ */
+class Fishing
+@Inject
+constructor(
+    private val xpMods: XpModifiers,
+    private val invisibleLvls: InvisibleLevels,
+    private val mapClock: MapClock,
+) : PluginScript() {
+    override fun ScriptContext.startup() {
+        onOpContentNpc1("content.fishing_spot") { smallNet(it.npc) }
+        onOpContentNpcU("content.fishing_spot", FishingRates.NET_OBJ) { smallNet(it.npc) }
+    }
+
+    private fun ProtectedAccess.smallNet(npc: Npc) {
+        if (!hasNet()) {
+            mes("You need a small fishing net to fish here.")
+            return
+        }
+
+        if (!FishingRates.canFish(player.fishingLvl)) {
+            mes("You need a Fishing level of ${FishingRates.shrimp.level} to fish here.")
+            return
+        }
+
+        if (inv.isFull()) {
+            mes("Your inventory is too full to hold any more fish.")
+            soundSynth("synth.pillory_wrong")
+            resetAnim()
+            return
+        }
+
+        // Cold start: arm delays, play cast anim/spam once, then re-enter when ready.
+        if (actionDelay < mapClock) {
+            val coldStart = skillAnimDelay < mapClock
+            actionDelay = mapClock + 3
+            skillAnimDelay = mapClock + 3
+            if (coldStart) {
+                anim(FishingRates.NET_ANIM)
+                spam("You cast out your net...")
+            }
+            opNpc1(npc)
+            return
+        }
+
+        if (skillAnimDelay <= mapClock) {
+            skillAnimDelay = mapClock + 4
+            anim(FishingRates.NET_ANIM)
+        }
+
+        var caught: FishCatch? = null
+        if (actionDelay == mapClock) {
+            actionDelay = mapClock + FishingRates.ACTION_DELAY
+            val (low, high) = FishingRates.spotSuccessRates()
+            if (statRandom("stat.fishing", low, high, invisibleLvls)) {
+                val wantAnchovies = player.fishingLvl >= FishingRates.anchovies.level && random.randomBoolean()
+                caught = FishingRates.resolveCatch(player.fishingLvl, wantAnchovies)
+            }
+        }
+
+        if (caught != null) {
+            val xp = caught.xp * xpMods.get(player, "stat.fishing")
+            val product =
+                SkillingProduct(
+                    player = player,
+                    skill = "stat.fishing",
+                    item = caught.item,
+                    count = 1,
+                    experience = xp,
+                    grantsExperience = true,
+                    source = SkillingProductSource.Fishing(npc, caught.item),
+                    depletes = false,
+                )
+            when (awardSkillingProduct(product)) {
+                SkillingAwardResult.InventoryFull -> {
+                    mes("Your inventory is too full to hold any more fish.")
+                    soundSynth("synth.pillory_wrong")
+                    resetAnim()
+                    return
+                }
+                SkillingAwardResult.Cancelled -> Unit
+                SkillingAwardResult.Success -> {
+                    val name = getInvObj(InvObj(caught.item)).name.lowercase()
+                    spam("You catch some $name.")
+                }
+            }
+        }
+
+        if (inv.isFull()) {
+            mes("Your inventory is too full to hold any more fish.")
+            soundSynth("synth.pillory_wrong")
+            resetAnim()
+            return
+        }
+
+        opNpc1(npc)
+    }
+
+    private fun ProtectedAccess.hasNet(): Boolean =
+        FishingRates.NET_OBJ in inv || "content.fishing_net" in inv
+}

--- a/content/skills/fishing/src/main/resources/gamevals.toml
+++ b/content/skills/fishing/src/main/resources/gamevals.toml
@@ -1,0 +1,3 @@
+[gamevals.content]
+fishing_spot = 54
+fishing_net = 55

--- a/content/skills/fishing/src/test/kotlin/org/rsmod/content/skills/fishing/configs/FishingRatesTest.kt
+++ b/content/skills/fishing/src/test/kotlin/org/rsmod/content/skills/fishing/configs/FishingRatesTest.kt
@@ -1,0 +1,38 @@
+package org.rsmod.content.skills.fishing.configs
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class FishingRatesTest {
+    @Test
+    fun `shrimp available from level 1`() {
+        assertTrue(FishingRates.canFish(1))
+        assertEquals(FishingRates.shrimp, FishingRates.resolveCatch(1, rollAnchovies = true))
+        assertEquals(FishingRates.shrimp, FishingRates.resolveCatch(14, rollAnchovies = true))
+    }
+
+    @Test
+    fun `anchovies only when level 15+ and roll selects them`() {
+        assertEquals(FishingRates.anchovies, FishingRates.resolveCatch(15, rollAnchovies = true))
+        assertEquals(FishingRates.shrimp, FishingRates.resolveCatch(15, rollAnchovies = false))
+        assertEquals(FishingRates.anchovies, FishingRates.resolveCatch(99, rollAnchovies = true))
+    }
+
+    @Test
+    fun `xp and levels match OSRS whole values`() {
+        assertEquals(1, FishingRates.shrimp.level)
+        assertEquals(10.0, FishingRates.shrimp.xp)
+        assertEquals(15, FishingRates.anchovies.level)
+        assertEquals(40.0, FishingRates.anchovies.xp)
+        assertFalse(FishingRates.canFish(0))
+    }
+
+    @Test
+    fun `spot success rates are mining-style low high ints`() {
+        val (low, high) = FishingRates.spotSuccessRates()
+        assertTrue(low > 0)
+        assertTrue(high > low)
+    }
+}


### PR DESCRIPTION
## Summary
- Implement Small Net fishing for Draynor `npc.0_48_50_saltfish` via `content.fishing_spot` / `content.fishing_net`
- Catch shrimp (level 1) and equal-weight shrimp/anchovies at 15+; whole XP 10/40
- Extend `SkillingProductSource` with a Fishing variant; do not use the empty `RiverFishingRow` stub

## Test plan
- [x] `gradlew :content:skills:fishing:test` / compile
- [x] `:or-cache:buildCache` (no `install` / RSA regen)
- [ ] In-game: bring `obj.net` to Draynor fishing spot, Small Net until catch + inv-full stop
- [ ] Confirm bait op remains unbound

## Notes
- Success rates 24/96 are medium-confidence (documented in openrune-rs `docs/PROTOCOL.md`)
- Spots do not deplete; other saltfish NPCs not tagged yet