### PR TITLE
fix: always send temp move speed on telejump

### DIFF
--- a/api/net/src/main/kotlin/org/rsmod/api/net/rsprot/RspCycle.kt
+++ b/api/net/src/main/kotlin/org/rsmod/api/net/rsprot/RspCycle.kt
@@ -152,7 +152,10 @@ class RspCycle(
             knownCachedSpeed = cachedMoveSpeed
         }
         val moveSpeed = resolvePendingMoveSpeed()
-        if (moveSpeed != cachedMoveSpeed && coords != knownCoords) {
+        // Telejumps always transmit their temp move speed; it is what tells the client to snap
+        // instead of interpolating, and `cachedMoveSpeed` is already `Stationary` until the
+        // player moves for the first time.
+        if ((moveSpeed != cachedMoveSpeed || pendingTelejump) && coords != knownCoords) {
             val extendedInfo = playerInfo.avatar.extendedInfo
             extendedInfo.setTempMoveSpeed(moveSpeed.steps)
         }


### PR DESCRIPTION
Teleporting before taking a step after logging in leaves the player walking to the destination instead of jumping to it, as reported in #151.

`telejump` resolves to `MoveSpeed.Stationary` (127), which is what tells the client to snap rather than interpolate. It was only transmitted when the resolved speed differed from `cachedMoveSpeed`, and that stays `Stationary` until `PlayerMovementProcessor` consumes the player's first route, so the marker was dropped for anyone who had not moved yet. Taking a single step assigns `Walk`, which is why walking first appears to fix it.

Verified on revision 240 by logging the values at the call site while teleporting in a client. Before the change, a teleport with no prior movement resolved `Stationary` against a cached `Stationary` and skipped the block; after it, the same teleport transmits. A teleport taken after one step transmitted in both cases.

How visible this is depends on the distance: without the marker the client interpolates towards the destination, so a short teleport looks like a slow slide and a level change drops the plane first, while a teleport outside the loaded scene still snaps because the client falls back to a hard reset.

Fixes #151.
