### PR TITLE
feat: fill 245 unknown drop rates from the wiki Dropsline bucket

### DIFF
--- a/content/drops/src/main/kotlin/org/rsmod/content/drops/tables/monsters/AlchemicalHydraDropTable.kt
+++ b/content/drops/src/main/kotlin/org/rsmod/content/drops/tables/monsters/AlchemicalHydraDropTable.kt
@@ -62,6 +62,21 @@ public val alchemicalHydraDropTable: RSDropTable<Player, DropRollItem> = RSDropT
         1 weight "obj.crystal_key" count 1
 
         1 weight SharedDropTables.rareDrop
+        10 outOf 1811 separate "obj.hydra_eye" count 1
+        10 outOf 1811 separate "obj.hydra_fang" count 1
+        10 outOf 1811 separate "obj.hydra_heart" count 1
+        1 outOf 513 separate "obj.hydra_tail" count 1
+        1 outOf 514 separate "obj.hydra_leather" count 1
+        1 outOf 1001 separate "obj.hydra_claw" count 1
+        1 outOf 2001 separate "obj.dragon_knife" count 500..1000
+        5 outOf 323 separate "obj.cert_unidentified_avantoe" count 10..15
+        5 outOf 323 separate "obj.cert_unidentified_kwuarm" count 25..30
+        5 outOf 404 separate "obj.cert_unidentified_ranarr" count 10..15
+        5 outOf 404 separate "obj.cert_unidentified_snapdragon" count 10..15
+        5 outOf 404 separate "obj.cert_unidentified_cadantine" count 25..30
+        5 outOf 404 separate "obj.cert_unidentified_dwarf_weed" count 25..30
+        10 outOf 1077 separate "obj.cert_unidentified_lantadyme" count 25..30
+        10 outOf 1077 separate "obj.cert_unidentified_torstol" count 10..15
     },
     tertiaries = rsPlayerTertiaryTable {
         onBuilder { brimstoneKeyRoll(konarTaskBonus = true) }
@@ -78,18 +93,3 @@ public val alchemicalHydraDropTable: RSDropTable<Player, DropRollItem> = RSDropT
 )
 
 // Unknown wiki drop rates (text rarity — need data collection):
-//   - Hydra's eye [main/1/{{#expr:180/(1999/2000*1999/2000*999/1000*511/512*511/512) round 1}}]
-//   - Hydra's fang [main/1/{{#expr:180/(1999/2000*1999/2000*999/1000*511/512*511/512) round 1}}]
-//   - Hydra's heart [main/1/{{#expr:180/(1999/2000*1999/2000*999/1000*511/512*511/512) round 1}}]
-//   - Hydra tail [main/1/{{#expr:512/(1999/2000*1999/2000*999/1000) round 1}}]
-//   - Hydra leather [main/1/{{#expr:512/(1999/2000*1999/2000*999/1000*511/512) round 1}}]
-//   - Hydra's claw [main/1/{{#expr:1000/(1999/2000*1999/2000) round 1}}]
-//   - Dragon knife [main/1/{{#expr:2000/(1999/2000) round 1}}]
-//   - Grimy avantoe [main/1/{{#expr:1/(5*{{#var:herbbase}}) round 1}}]
-//   - Grimy kwuarm [main/1/{{#expr:1/(5*{{#var:herbbase}}) round 1}}]
-//   - Grimy ranarr weed [main/1/{{#expr:1/(4*{{#var:herbbase}}) round 1}}]
-//   - Grimy snapdragon [main/1/{{#expr:1/(4*{{#var:herbbase}}) round 1}}]
-//   - Grimy cadantine [main/1/{{#expr:1/(4*{{#var:herbbase}}) round 1}}]
-//   - Grimy dwarf weed [main/1/{{#expr:1/(4*{{#var:herbbase}}) round 1}}]
-//   - Grimy lantadyme [main/1/{{#expr:1/(3*{{#var:herbbase}}) round 1}}]
-//   - Grimy torstol [main/1/{{#expr:1/(3*{{#var:herbbase}}) round 1}}]

--- a/content/drops/src/main/kotlin/org/rsmod/content/drops/tables/monsters/ArmouredKrakenDropTable.kt
+++ b/content/drops/src/main/kotlin/org/rsmod/content/drops/tables/monsters/ArmouredKrakenDropTable.kt
@@ -49,6 +49,35 @@ public val armouredKrakenDropTable: RSDropTable<Player, DropRollItem> = RSDropTa
         8 weight SharedDropTables.herb
         1 weight SharedDropTables.gem
         11 weight nothing()
+        10 outOf 727 separate "obj.toadflax_seed" count 1
+        5 outOf 531 separate "obj.irit_seed" count 1
+        5 outOf 549 separate "obj.belladonna_seed" count 1
+        5 outOf 764 separate "obj.avantoe_seed" count 1
+        10 outOf 1553 separate "obj.poisonivy_bush_seed" count 1
+        10 outOf 1587 separate "obj.camphor_seed" count 1
+        5 outOf 818 separate "obj.cactus_seed" count 1
+        10 outOf 2249 separate "obj.potato_cactus_seed" count 1
+        10 outOf 2273 separate "obj.kwuarm_seed" count 1
+        5 outOf 1714 separate "obj.snapdragon_seed" count 1
+        10 outOf 4543 separate "obj.limpwurt_seed" count 1
+        10 outOf 4751 separate "obj.strawberry_seed" count 1
+        10 outOf 4907 separate "obj.cadantine_seed" count 1
+        10 outOf 4979 separate "obj.marrentill_seed" count 1
+        1 outOf 595 separate "obj.ironwood_seed" count 1
+        2 outOf 1353 separate "obj.jangerberry_bush_seed" count 1
+        5 outOf 3409 separate "obj.lantadyme_seed" count 1
+        5 outOf 3661 separate "obj.tarromin_seed" count 1
+        5 outOf 3749 separate "obj.wildblood_hop_seed" count 1
+        10 outOf 8107 separate "obj.snape_grass_seed" count 3
+        10 outOf 9879 separate "obj.watermelon_seed" count 1
+        1 outOf 1111 separate "obj.harralander_seed" count 1
+        1 outOf 1117 separate "obj.dwarf_weed_seed" count 1
+        1 outOf 1556 separate "obj.snape_grass_seed" count 1
+        1 outOf 1596 separate "obj.ranarr_seed" count 1
+        1 outOf 1751 separate "obj.torstol_seed" count 1
+        1 outOf 1831 separate "obj.whiteberry_bush_seed" count 1
+        1 outOf 2146 separate "obj.mushroom_seed" count 1
+        1 outOf 2380 separate "obj.rosewood_seed" count 1
     },
     tertiaries = rsPlayerTertiaryTable {
         1 outOf 2 weight "obj.sailing_armoured_kraken_tentacle" count 1 condition { player ->
@@ -63,32 +92,3 @@ public val armouredKrakenDropTable: RSDropTable<Player, DropRollItem> = RSDropTa
 )
 
 // Unknown wiki drop rates (text rarity — need data collection):
-//   - Toadflax seed [main/1/{{#expr:1/({{#var:rareseed}}*216 + {{#var:uncseed}}*27) round 1}}]
-//   - Irit seed [main/1/{{#expr:1/({{#var:rareseed}}*148 + {{#var:uncseed}}*18) round 1}}]
-//   - Belladonna seed [main/1/{{#expr:1/({{#var:rareseed}}*143 + {{#var:uncseed}}*18) round 1}}]
-//   - Avantoe seed [main/1/{{#expr:1/({{#var:rareseed}}*103 + {{#var:uncseed}}*12) round 1}}]
-//   - Poison ivy seed [main/1/{{#expr:1/({{#var:rareseed}}*101 + {{#var:uncseed}}*13) round 1}}]
-//   - Camphor seed [main/1/{{#expr:1/({{#var:sailseed}}*15) round 1}}]
-//   - Cactus seed [main/1/{{#expr:1/({{#var:rareseed}}*96 + {{#var:uncseed}}*12) round 1}}]
-//   - Potato cactus seed [main/1/{{#expr:1/({{#var:rareseed}}*70 + {{#var:uncseed}}*8) round 1}}]
-//   - Kwuarm seed [main/1/{{#expr:1/({{#var:rareseed}}*69 + {{#var:uncseed}}*9) round 1}}]
-//   - Snapdragon seed [main/1/{{#expr:1/({{#var:rareseed}}*46 + {{#var:uncseed}}*5) round 1}}]
-//   - Limpwurt seed [main/1/{{#expr:1/({{#var:uncseed}}*137) round 1}}]
-//   - Strawberry seed [main/1/{{#expr:1/({{#var:uncseed}}*131) round 1}}]
-//   - Cadantine seed [main/1/{{#expr:1/({{#var:rareseed}}*32 + {{#var:uncseed}}*4) round 1}}]
-//   - Marrentill seed [main/1/{{#expr:1/({{#var:uncseed}}*125) round 1}}]
-//   - Ironwood seed [main/1/{{#expr:1/({{#var:sailseed}}*4) round 1}}]
-//   - Jangerberry seed [main/1/{{#expr:1/({{#var:uncseed}}*92) round 1}}]
-//   - Lantadyme seed [main/1/{{#expr:1/({{#var:rareseed}}*23 + {{#var:uncseed}}*3) round 1}}]
-//   - Tarromin seed [main/1/{{#expr:1/({{#var:uncseed}}*85) round 1}}]
-//   - Wildblood seed [main/1/{{#expr:1/({{#var:uncseed}}*83) round 1}}]
-//   - Snape grass seed [main/1/{{#expr:1/({{#var:rareseed}}*20) round 1}}]
-//   - Watermelon seed [main/1/{{#expr:1/({{#var:uncseed}}*63) round 1}}]
-//   - Harralander seed [main/1/{{#expr:1/({{#var:uncseed}}*56) round 0}}]
-//   - Dwarf weed seed [main/1/{{#expr:1/({{#var:rareseed}}*14 + {{#var:uncseed}}*2) round 0}}]
-//   - Snape grass seed [main/1/{{#expr:1/({{#var:uncseed}}*40) round 0}}]
-//   - Ranarr seed [main/1/{{#expr:1/({{#var:uncseed}}*39) round 0}}]
-//   - Torstol seed [main/1/{{#expr:1/({{#var:rareseed}}*9 + {{#var:uncseed}}*1) round 0}}]
-//   - Whiteberry seed [main/1/{{#expr:1/({{#var:uncseed}}*34) round 0}}]
-//   - Mushroom spore [main/1/{{#expr:1/({{#var:uncseed}}*29) round 0}}]
-//   - Rosewood seed [main/1/{{#expr:1/({{#var:sailseed}}*1) round 0}}]

--- a/content/drops/src/main/kotlin/org/rsmod/content/drops/tables/monsters/ColossalHydraDropTable.kt
+++ b/content/drops/src/main/kotlin/org/rsmod/content/drops/tables/monsters/ColossalHydraDropTable.kt
@@ -63,6 +63,16 @@ public val colossalHydraDropTable: RSDropTable<Player, DropRollItem> = RSDropTab
         1 weight SharedDropTables.gem
         4 weight SharedDropTables.rareSeed
         4 weight nothing()
+        1 outOf 192 separate "obj.cert_unidentified_avantoe" count 3
+        1 outOf 240 separate "obj.cert_unidentified_ranarr" count 3
+        1 outOf 320 separate "obj.cert_unidentified_snapdragon" count 3
+        1 outOf 320 separate "obj.cert_unidentified_torstol" count 3
+        1 outOf 256 separate "obj.xbows_bolt_tips_diamond" count 20
+        5 outOf 1422 separate "obj.xbows_bolt_tips_ruby" count 20
+        5 outOf 1422 separate "obj.xbows_bolt_tips_emerald" count 20
+        10 outOf 3657 separate "obj.xbows_bolt_tips_dragonstone" count 20
+        10 outOf 8533 separate "obj.xbows_bolt_tips_onyx" count 20
+        1 outOf 1280 separate "obj.xbows_bolt_tips_sapphire" count 20
     },
     tertiaries = rsPlayerTertiaryTable {
         10 outOf 121 weight "obj.trail_clue_hard_map001" count 1 transformObj { player ->
@@ -75,13 +85,3 @@ public val colossalHydraDropTable: RSDropTable<Player, DropRollItem> = RSDropTab
 )
 
 // Unknown wiki drop rates (text rarity — need data collection):
-//   - Grimy avantoe [main/1/{{#expr:1/(5*{{#var:uht}}) round 2}}]
-//   - Grimy ranarr weed [main/1/{{#expr:1/(4*{{#var:uht}}) round 2}}]
-//   - Grimy snapdragon [main/1/{{#expr:1/(3*{{#var:uht}}) round 2}}]
-//   - Grimy torstol [main/1/{{#expr:1/(3*{{#var:uht}}) round 2}}]
-//   - Diamond bolt tips [main/1/{{#expr:1/(10*{{#var:bolttipbase}}) round 1}}]
-//   - Ruby bolt tips [main/1/{{#expr:1/(9*{{#var:bolttipbase}}) round 1}}]
-//   - Emerald bolt tips [main/1/{{#expr:1/(9*{{#var:bolttipbase}}) round 1}}]
-//   - Dragonstone bolt tips [main/1/{{#expr:1/(7*{{#var:bolttipbase}}) round 1}}]
-//   - Onyx bolt tips [main/1/{{#expr:1/(3*{{#var:bolttipbase}}) round 1}}]
-//   - Sapphire bolt tips [main/1/{{#expr:1/(2*{{#var:bolttipbase}}) round 1}}]

--- a/content/drops/src/main/kotlin/org/rsmod/content/drops/tables/monsters/DrakeDropTable.kt
+++ b/content/drops/src/main/kotlin/org/rsmod/content/drops/tables/monsters/DrakeDropTable.kt
@@ -53,6 +53,14 @@ public val drakeDropTable: RSDropTable<Player, DropRollItem> = RSDropTable(
         1 weight SharedDropTables.gem
         1 weight SharedDropTables.rareSeed
         5 weight nothing()
+        5 outOf 496 separate "obj.unidentified_avantoe" count 1..3
+        5 outOf 496 separate "obj.unidentified_kwuarm" count 1..3
+        1 outOf 124 separate "obj.unidentified_ranarr" count 1..3
+        1 outOf 124 separate "obj.unidentified_snapdragon" count 1..3
+        1 outOf 124 separate "obj.unidentified_cadantine" count 1..3
+        1 outOf 124 separate "obj.unidentified_dwarf_weed" count 1..3
+        10 outOf 1653 separate "obj.unidentified_lantadyme" count 1..3
+        10 outOf 1653 separate "obj.unidentified_torstol" count 1..3
     },
     tertiaries = rsPlayerTertiaryTable {
         onBuilder { brimstoneKeyRoll(konarTaskBonus = true) }
@@ -63,11 +71,3 @@ public val drakeDropTable: RSDropTable<Player, DropRollItem> = RSDropTable(
 )
 
 // Unknown wiki drop rates (text rarity — need data collection):
-//   - Grimy avantoe [main/1/{{#expr:1/(5*{{#var:herbbase}}) round 1}}]
-//   - Grimy kwuarm [main/1/{{#expr:1/(5*{{#var:herbbase}}) round 1}}]
-//   - Grimy ranarr weed [main/1/{{#expr:1/(4*{{#var:herbbase}}) round 1}}]
-//   - Grimy snapdragon [main/1/{{#expr:1/(4*{{#var:herbbase}}) round 1}}]
-//   - Grimy cadantine [main/1/{{#expr:1/(4*{{#var:herbbase}}) round 1}}]
-//   - Grimy dwarf weed [main/1/{{#expr:1/(4*{{#var:herbbase}}) round 1}}]
-//   - Grimy lantadyme [main/1/{{#expr:1/(3*{{#var:herbbase}}) round 1}}]
-//   - Grimy torstol [main/1/{{#expr:1/(3*{{#var:herbbase}}) round 1}}]

--- a/content/drops/src/main/kotlin/org/rsmod/content/drops/tables/monsters/HydraDropTable.kt
+++ b/content/drops/src/main/kotlin/org/rsmod/content/drops/tables/monsters/HydraDropTable.kt
@@ -58,6 +58,16 @@ public val hydraDropTable: RSDropTable<Player, DropRollItem> = RSDropTable(
         1 weight SharedDropTables.gem
         4 weight SharedDropTables.rareSeed
         4 weight nothing()
+        1 outOf 192 separate "obj.cert_unidentified_avantoe" count 3
+        1 outOf 240 separate "obj.cert_unidentified_ranarr" count 3
+        1 outOf 320 separate "obj.cert_unidentified_snapdragon" count 3
+        1 outOf 320 separate "obj.cert_unidentified_torstol" count 3
+        1 outOf 256 separate "obj.xbows_bolt_tips_diamond" count 20
+        5 outOf 1422 separate "obj.xbows_bolt_tips_ruby" count 20
+        5 outOf 1422 separate "obj.xbows_bolt_tips_emerald" count 20
+        10 outOf 3657 separate "obj.xbows_bolt_tips_dragonstone" count 20
+        10 outOf 8533 separate "obj.xbows_bolt_tips_onyx" count 20
+        1 outOf 1280 separate "obj.xbows_bolt_tips_sapphire" count 20
     },
     tertiaries = rsPlayerTertiaryTable {
         onBuilder { brimstoneKeyRoll(konarTaskBonus = true) }
@@ -71,13 +81,3 @@ public val hydraDropTable: RSDropTable<Player, DropRollItem> = RSDropTable(
 )
 
 // Unknown wiki drop rates (text rarity — need data collection):
-//   - Grimy avantoe [main/1/{{#expr:1/(5*{{#var:uht}}) round 2}}]
-//   - Grimy ranarr weed [main/1/{{#expr:1/(4*{{#var:uht}}) round 2}}]
-//   - Grimy snapdragon [main/1/{{#expr:1/(3*{{#var:uht}}) round 2}}]
-//   - Grimy torstol [main/1/{{#expr:1/(3*{{#var:uht}}) round 2}}]
-//   - Diamond bolt tips [main/1/{{#expr:1/(10*{{#var:bolttipbase}}) round 1}}]
-//   - Ruby bolt tips [main/1/{{#expr:1/(9*{{#var:bolttipbase}}) round 1}}]
-//   - Emerald bolt tips [main/1/{{#expr:1/(9*{{#var:bolttipbase}}) round 1}}]
-//   - Dragonstone bolt tips [main/1/{{#expr:1/(7*{{#var:bolttipbase}}) round 1}}]
-//   - Onyx bolt tips [main/1/{{#expr:1/(3*{{#var:bolttipbase}}) round 1}}]
-//   - Sapphire bolt tips [main/1/{{#expr:1/(2*{{#var:bolttipbase}}) round 1}}]

--- a/content/drops/src/main/kotlin/org/rsmod/content/drops/tables/monsters/LavaStrykewyrmDropTable.kt
+++ b/content/drops/src/main/kotlin/org/rsmod/content/drops/tables/monsters/LavaStrykewyrmDropTable.kt
@@ -58,6 +58,12 @@ public val lavaStrykewyrmDropTable: RSDropTable<Player, DropRollItem> = RSDropTa
 
         2 weight SharedDropTables.herb
         5 weight nothing()
+        5 outOf 471 separate "obj.xbows_bolt_tips_diamond" count 5..10
+        5 outOf 589 separate "obj.xbows_bolt_tips_emerald" count 5..10
+        5 outOf 589 separate "obj.xbows_bolt_tips_ruby" count 5..10
+        1 outOf 157 separate "obj.xbows_bolt_tips_dragonstone" count 5..10
+        2 outOf 673 separate "obj.xbows_bolt_tips_onyx" count 5..10
+        1 outOf 471 separate "obj.xbows_bolt_tips_sapphire" count 5..10
     },
     tertiaries = rsPlayerTertiaryTable {
         onBuilder { brimstoneKeyRoll(konarTaskBonus = true) }
@@ -68,9 +74,3 @@ public val lavaStrykewyrmDropTable: RSDropTable<Player, DropRollItem> = RSDropTa
 )
 
 // Unknown wiki drop rates (text rarity — need data collection):
-//   - Diamond bolt tips [main/1/{{#expr:1/(5/128 * 25/92) round 1}}]
-//   - Emerald bolt tips [main/1/{{#expr:1/(5/128 * 20/92) round 1}}]
-//   - Ruby bolt tips [main/1/{{#expr:1/(5/128 * 20/92) round 1}}]
-//   - Dragonstone bolt tips [main/1/{{#expr:1/(5/128 * 15/92) round 1}}]
-//   - Onyx bolt tips [main/1/{{#expr:1/(5/128 * 7/92) round 1}}]
-//   - Sapphire bolt tips [main/1/{{#expr:1/(5/128 * 5/92) round 1}}]

--- a/content/drops/src/main/kotlin/org/rsmod/content/drops/tables/monsters/MantaRayMonsterDropTable.kt
+++ b/content/drops/src/main/kotlin/org/rsmod/content/drops/tables/monsters/MantaRayMonsterDropTable.kt
@@ -36,6 +36,29 @@ public val mantaRayMonsterDropTable: RSDropTable<Player, DropRollItem> = RSDropT
 
         4 weight SharedDropTables.combatHerb
         70 weight nothing()
+        10 outOf 2063 separate "obj.ranarr_seed" count 1
+        5 outOf 1473 separate "obj.watermelon_seed" count 15
+        5 outOf 1547 separate "obj.willow_seed" count 1
+        5 outOf 1719 separate "obj.mahogany_seed" count 1
+        5 outOf 1719 separate "obj.maple_seed" count 1
+        5 outOf 1719 separate "obj.teak_seed" count 1
+        5 outOf 1719 separate "obj.yew_seed" count 1
+        1 outOf 442 separate "obj.papaya_tree_seed" count 1
+        2 outOf 1125 separate "obj.magic_tree_seed" count 1
+        5 outOf 3094 separate "obj.palm_tree_seed" count 1
+        5 outOf 3867 separate "obj.spirit_tree_seed" count 1
+        10 outOf 10313 separate "obj.dragonfruit_tree_seed" count 1
+        10 outOf 15469 separate "obj.celastrus_tree_seed" count 1
+        10 outOf 15469 separate "obj.redwood_tree_seed" count 1
+        5 outOf 104 separate "obj.unidentified_guam" count 2..3
+        5 outOf 139 separate "obj.unidentified_marentill" count 2..3
+        10 outOf 371 separate "obj.unidentified_tarromin" count 2..3
+        5 outOf 238 separate "obj.unidentified_harralander" count 2..3
+        5 outOf 232 separate "obj.unidentified_ranarr" count 2..3
+        5 outOf 417 separate "obj.unidentified_irit" count 2..3
+        10 outOf 653 separate "obj.unidentified_avantoe" count 2..3
+        1 outOf 198 separate "obj.unidentified_snapdragon" count 2..3
+        1 outOf 264 separate "obj.unidentified_torstol" count 2..3
     },
     tertiaries = rsPlayerTertiaryTable {
         1 outOf 10 weight "obj.sailing_manta_ray_skin" count 1 condition { player ->
@@ -63,30 +86,7 @@ public val mantaRayMonsterDropTable: RSDropTable<Player, DropRollItem> = RSDropT
 //   - Snape grass seed [main/1/{{#expr:1/({{#var:rareseed}}*20) round 1}}]
 //   - Dwarf weed seed [main/1/{{#expr:1/({{#var:rareseed}}*14) round 1}}]
 //   - Torstol seed [main/1/{{#expr:1/({{#var:rareseed}}*9 + {{#var:treeseed}}*22) round 1}}]
-//   - Ranarr seed [main/1/{{#expr:1/({{#var:treeseed}}*30) round 1}}]
-//   - Watermelon seed [main/1/{{#expr:1/({{#var:treeseed}}*21) round 1}}]
-//   - Willow seed [main/1/{{#expr:1/({{#var:treeseed}}*20) round 1}}]
-//   - Mahogany seed [main/1/{{#expr:1/({{#var:treeseed}}*18) round 1}}]
-//   - Maple seed [main/1/{{#expr:1/({{#var:treeseed}}*18) round 1}}]
-//   - Teak seed [main/1/{{#expr:1/({{#var:treeseed}}*18) round 1}}]
-//   - Yew seed [main/1/{{#expr:1/({{#var:treeseed}}*18) round 1}}]
-//   - Papaya tree seed [main/1/{{#expr:1/({{#var:treeseed}}*14) round 1}}]
-//   - Magic seed [main/1/{{#expr:1/({{#var:treeseed}}*11) round 1}}]
-//   - Palm tree seed [main/1/{{#expr:1/({{#var:treeseed}}*10) round 1}}]
-//   - Spirit seed [main/1/{{#expr:1/({{#var:treeseed}}*8) round 1}}]
-//   - Dragonfruit tree seed [main/1/{{#expr:1/({{#var:treeseed}}*6) round 1}}]
-//   - Celastrus seed [main/1/{{#expr:1/({{#var:treeseed}}*4) round 1}}]
-//   - Redwood tree seed [main/1/{{#expr:1/({{#var:treeseed}}*4) round 1}}]
-//   - Grimy guam leaf [main/1/{{#expr:1/({{#var:hdt}}*32) round 1}}]
-//   - Grimy marrentill [main/1/{{#expr:1/({{#var:hdt}}*24) round 1}}]
-//   - Grimy tarromin [main/1/{{#expr:1/({{#var:hdt}}*18) round 1}}]
-//   - Grimy harralander [main/1/{{#expr:1/({{#var:hdt}}*14) round 1}}]
-//   - Grimy ranarr weed [main/1/{{#expr:1/({{#var:hdt}}*11 + {{#var:usefulHdt}}*4) round 1}}]
-//   - Grimy irit leaf [main/1/{{#expr:1/({{#var:hdt}}*8) round 1}}]
-//   - Grimy avantoe [main/1/{{#expr:1/({{#var:hdt}}*6 + {{#var:usefulHdt}}*5) round 1}}]
 //   - Grimy kwuarm [main/1/{{#expr:1/({{#var:hdt}}*5) round 1}}]
 //   - Grimy cadantine [main/1/{{#expr:1/({{#var:hdt}}*4) round 1}}]
 //   - Grimy lantadyme [main/1/{{#expr:1/({{#var:hdt}}*3) round 1}}]
 //   - Grimy dwarf weed [main/1/{{#expr:1/({{#var:hdt}}*3) round 1}}]
-//   - Grimy snapdragon [main/1/{{#expr:1/({{#var:usefulHdt}}*4) round 1}}]
-//   - Grimy torstol [main/1/{{#expr:1/({{#var:usefulHdt}}*3) round 1}}]

--- a/content/drops/src/main/kotlin/org/rsmod/content/drops/tables/monsters/ShellbaneGryphonDropTable.kt
+++ b/content/drops/src/main/kotlin/org/rsmod/content/drops/tables/monsters/ShellbaneGryphonDropTable.kt
@@ -46,6 +46,25 @@ public val shellbaneGryphonDropTable: RSDropTable<Player, DropRollItem> = RSDrop
         6 weight SharedDropTables.herb
         1 weight SharedDropTables.gem
         25 weight nothing()
+        10 outOf 171 separate "obj.potato_seed" count 1..4
+        10 outOf 341 separate "obj.onion_seed" count 1..3
+        10 outOf 683 separate "obj.cabbage_seed" count 1..3
+        5 outOf 186 separate "obj.tomato_seed" count 1..2
+        2 outOf 149 separate "obj.sweetcorn_seed" count 1..2
+        10 outOf 1489 separate "obj.strawberry_seed" count 1
+        10 outOf 2979 separate "obj.watermelon_seed" count 1
+        10 outOf 2979 separate "obj.snape_grass_seed" count 1
+        10 outOf 853 separate "obj.unidentified_guam" count 1
+        5 outOf 569 separate "obj.unidentified_marentill" count 1
+        10 outOf 1517 separate "obj.unidentified_tarromin" count 1
+        1 outOf 195 separate "obj.unidentified_harralander" count 1
+        5 outOf 1241 separate "obj.unidentified_ranarr" count 1
+        10 outOf 3413 separate "obj.unidentified_irit" count 1
+        10 outOf 4551 separate "obj.unidentified_avantoe" count 1
+        5 outOf 356 separate "obj.unidentified_kwuarm" count 1
+        1 outOf 89 separate "obj.unidentified_cadantine" count 1
+        10 outOf 1187 separate "obj.unidentified_lantadyme" count 1
+        1 outOf 92 separate "obj.unidentified_dwarf_weed" count 1
     },
     tertiaries = rsPlayerTertiaryTable {
         1 outOf 1 weight "obj.trail_elite_emote_exp1" count 1 condition { player ->
@@ -65,22 +84,3 @@ public val shellbaneGryphonDropTable: RSDropTable<Player, DropRollItem> = RSDrop
 )
 
 // Unknown wiki drop rates (text rarity — need data collection):
-//   - Potato seed [main/1/{{#expr:1/({{#var:allotseed}}*64) round 1}}]
-//   - Onion seed [main/1/{{#expr:1/({{#var:allotseed}}*32) round 1}}]
-//   - Cabbage seed [main/1/{{#expr:1/({{#var:allotseed}}*16) round 1}}]
-//   - Tomato seed [main/1/{{#expr:1/({{#var:allotseed}}*8 + {{#var:allotseedgood}}*8) round 1}}]
-//   - Sweetcorn seed [main/1/{{#expr:1/({{#var:allotseed}}*4 + {{#var:allotseedgood}}*4) round 1}}]
-//   - Strawberry seed [main/1/{{#expr:1/({{#var:allotseed}}*2 + {{#var:allotseedgood}}*2) round 1}}]
-//   - Watermelon seed [main/1/{{#expr:1/({{#var:allotseed}}*1 + {{#var:allotseedgood}}*1) round 1}}]
-//   - Snape grass seed [main/1/{{#expr:1/({{#var:allotseed}}*1 + {{#var:allotseedgood}}*1) round 1}}]
-//   - Grimy guam leaf [main/1/{{#expr:1/({{#var:herb}}*32) round 1}}]
-//   - Grimy marrentill [main/1/{{#expr:1/({{#var:herb}}*24) round 1}}]
-//   - Grimy tarromin [main/1/{{#expr:1/({{#var:herb}}*18) round 1}}]
-//   - Grimy harralander [main/1/{{#expr:1/({{#var:herb}}*14) round 1}}]
-//   - Grimy ranarr weed [main/1/{{#expr:1/({{#var:herb}}*11) round 1}}]
-//   - Grimy irit leaf [main/1/{{#expr:1/({{#var:herb}}*8) round 1}}]
-//   - Grimy avantoe [main/1/{{#expr:1/({{#var:herb}}*6) round 1}}]
-//   - Grimy kwuarm [main/1/{{#expr:1/({{#var:herb}}*5 + {{#var:combatherb}}*5) round 1}}]
-//   - Grimy cadantine [main/1/{{#expr:1/({{#var:herb}}*4 + {{#var:combatherb}}*4) round 1}}]
-//   - Grimy lantadyme [main/1/{{#expr:1/({{#var:herb}}*3 + {{#var:combatherb}}*3) round 1}}]
-//   - Grimy dwarf weed [main/1/{{#expr:1/({{#var:herb}}*3 + {{#var:combatherb}}*4) round 1}}]

--- a/content/drops/src/main/kotlin/org/rsmod/content/drops/tables/monsters/StingrayDropTable.kt
+++ b/content/drops/src/main/kotlin/org/rsmod/content/drops/tables/monsters/StingrayDropTable.kt
@@ -38,6 +38,41 @@ public val stingrayDropTable: RSDropTable<Player, DropRollItem> = RSDropTable(
 
         4 weight SharedDropTables.combatHerb
         86 weight nothing()
+        10 outOf 191 separate "obj.limpwurt_seed" count 1
+        1 outOf 20 separate "obj.strawberry_seed" count 1
+        10 outOf 209 separate "obj.marrentill_seed" count 1
+        5 outOf 142 separate "obj.jangerberry_bush_seed" count 1
+        5 outOf 154 separate "obj.tarromin_seed" count 1
+        2 outOf 63 separate "obj.wildblood_hop_seed" count 1
+        2 outOf 83 separate "obj.watermelon_seed" count 1
+        1 outOf 45 separate "obj.toadflax_seed" count 1
+        10 outOf 467 separate "obj.harralander_seed" count 1
+        5 outOf 327 separate "obj.snape_grass_seed" count 1
+        2 outOf 133 separate "obj.irit_seed" count 1
+        10 outOf 671 separate "obj.ranarr_seed" count 1
+        5 outOf 339 separate "obj.belladonna_seed" count 1
+        10 outOf 769 separate "obj.whiteberry_bush_seed" count 1
+        5 outOf 451 separate "obj.mushroom_seed" count 1
+        1 outOf 95 separate "obj.poisonivy_bush_seed" count 1
+        2 outOf 195 separate "obj.avantoe_seed" count 1
+        10 outOf 1013 separate "obj.cactus_seed" count 1
+        10 outOf 1381 separate "obj.kwuarm_seed" count 1
+        10 outOf 1447 separate "obj.potato_cactus_seed" count 1
+        1 outOf 225 separate "obj.snapdragon_seed" count 1
+        5 outOf 1519 separate "obj.cadantine_seed" count 1
+        5 outOf 2072 separate "obj.lantadyme_seed" count 1
+        10 outOf 6513 separate "obj.dwarf_weed_seed" count 1
+        10 outOf 9083 separate "obj.snape_grass_seed" count 3
+        1 outOf 1139 separate "obj.torstol_seed" count 1
+        10 outOf 143 separate "obj.unidentified_guam" count 1..2
+        1 outOf 19 separate "obj.unidentified_marentill" count 1..2
+        5 outOf 127 separate "obj.unidentified_tarromin" count 1..2
+        10 outOf 327 separate "obj.unidentified_harralander" count 1..2
+        5 outOf 188 separate "obj.unidentified_ranarr" count 1..2
+        10 outOf 571 separate "obj.unidentified_irit" count 1..2
+        2 outOf 123 separate "obj.unidentified_avantoe" count 1..2
+        1 outOf 400 separate "obj.unidentified_snapdragon" count 1..2
+        10 outOf 5333 separate "obj.unidentified_torstol" count 1..2
     },
     tertiaries = rsPlayerTertiaryTable {
         1 outOf 10 weight "obj.sailing_stingray_skin" count 1 condition { player ->
@@ -52,42 +87,7 @@ public val stingrayDropTable: RSDropTable<Player, DropRollItem> = RSDropTable(
 )
 
 // Unknown wiki drop rates (text rarity — need data collection):
-//   - Limpwurt seed [main/1/{{#expr:1/({{#var:uncseed}}*137) round 1}}]
-//   - Strawberry seed [main/1/{{#expr:1/({{#var:uncseed}}*131) round 1}}]
-//   - Marrentill seed [main/1/{{#expr:1/({{#var:uncseed}}*125) round 1}}]
-//   - Jangerberry seed [main/1/{{#expr:1/({{#var:uncseed}}*92) round 1}}]
-//   - Tarromin seed [main/1/{{#expr:1/({{#var:uncseed}}*85) round 1}}]
-//   - Wildblood seed [main/1/{{#expr:1/({{#var:uncseed}}*83) round 1}}]
-//   - Watermelon seed [main/1/{{#expr:1/({{#var:uncseed}}*63) round 1}}]
-//   - Toadflax seed [main/1/{{#expr:1/({{#var:rareseed}}*216 + {{#var:uncseed}}*27) round 1}}]
-//   - Harralander seed [main/1/{{#expr:1/({{#var:uncseed}}*56) round 1}}]
-//   - Snape grass seed [main/1/{{#expr:1/({{#var:uncseed}}*40) round 1}}]
-//   - Irit seed [main/1/{{#expr:1/({{#var:rareseed}}*148 + {{#var:uncseed}}*18) round 1}}]
-//   - Ranarr seed [main/1/{{#expr:1/({{#var:uncseed}}*39) round 1}}]
-//   - Belladonna seed [main/1/{{#expr:1/({{#var:rareseed}}*143 + {{#var:uncseed}}*18) round 1}}]
-//   - Whiteberry seed [main/1/{{#expr:1/({{#var:uncseed}}*34) round 1}}]
-//   - Mushroom spore [main/1/{{#expr:1/({{#var:uncseed}}*29) round 1}}]
-//   - Poison ivy seed [main/1/{{#expr:1/({{#var:rareseed}}*101 + {{#var:uncseed}}*13) round 1}}]
-//   - Avantoe seed [main/1/{{#expr:1/({{#var:rareseed}}*103 + {{#var:uncseed}}*12) round 1}}]
-//   - Cactus seed [main/1/{{#expr:1/({{#var:rareseed}}*96 + {{#var:uncseed}}*12) round 1}}]
-//   - Kwuarm seed [main/1/{{#expr:1/({{#var:rareseed}}*69 + {{#var:uncseed}}*9) round 1}}]
-//   - Potato cactus seed [main/1/{{#expr:1/({{#var:rareseed}}*70 + {{#var:uncseed}}*8) round 1}}]
-//   - Snapdragon seed [main/1/{{#expr:1/({{#var:rareseed}}*46 + {{#var:uncseed}}*5) round 1}}]
-//   - Cadantine seed [main/1/{{#expr:1/({{#var:rareseed}}*32 + {{#var:uncseed}}*4) round 1}}]
-//   - Lantadyme seed [main/1/{{#expr:1/({{#var:rareseed}}*23 + {{#var:uncseed}}*3) round 1}}]
-//   - Dwarf weed seed [main/1/{{#expr:1/({{#var:rareseed}}*14 + {{#var:uncseed}}*2) round 1}}]
-//   - Snape grass seed [main/1/{{#expr:1/({{#var:rareseed}}*20) round 1}}]
-//   - Torstol seed [main/1/{{#expr:1/({{#var:rareseed}}*9 + {{#var:uncseed}}*1) round 0}}]
-//   - Grimy guam leaf [main/1/{{#expr:1/({{#var:hdt}}*32) round 1}}]
-//   - Grimy marrentill [main/1/{{#expr:1/({{#var:hdt}}*24) round 1}}]
-//   - Grimy tarromin [main/1/{{#expr:1/({{#var:hdt}}*18) round 1}}]
-//   - Grimy harralander [main/1/{{#expr:1/({{#var:hdt}}*14) round 1}}]
-//   - Grimy ranarr weed [main/1/{{#expr:1/({{#var:hdt}}*11 + {{#var:usefulHdt}}*4) round 1}}]
-//   - Grimy irit leaf [main/1/{{#expr:1/({{#var:hdt}}*8) round 1}}]
-//   - Grimy avantoe [main/1/{{#expr:1/({{#var:hdt}}*6 + {{#var:usefulHdt}}*5) round 1}}]
 //   - Grimy kwuarm [main/1/{{#expr:1/({{#var:hdt}}*5) round 1}}]
 //   - Grimy cadantine [main/1/{{#expr:1/({{#var:hdt}}*4) round 1}}]
 //   - Grimy lantadyme [main/1/{{#expr:1/({{#var:hdt}}*3) round 1}}]
 //   - Grimy dwarf weed [main/1/{{#expr:1/({{#var:hdt}}*3) round 1}}]
-//   - Grimy snapdragon [main/1/{{#expr:1/({{#var:usefulHdt}}*4) round 1}}]
-//   - Grimy torstol [main/1/{{#expr:1/({{#var:usefulHdt}}*3) round 1}}]

--- a/content/drops/src/main/kotlin/org/rsmod/content/drops/tables/monsters/VeiledKrakenDropTable.kt
+++ b/content/drops/src/main/kotlin/org/rsmod/content/drops/tables/monsters/VeiledKrakenDropTable.kt
@@ -57,6 +57,9 @@ public val veiledKrakenDropTable: RSDropTable<Player, DropRollItem> = RSDropTabl
 
         9 weight SharedDropTables.herb
         2 weight nothing()
+        10 outOf 1813 separate "obj.camphor_seed" count 1
+        1 outOf 680 separate "obj.ironwood_seed" count 1
+        1 outOf 2720 separate "obj.rosewood_seed" count 1
     },
     tertiaries = rsPlayerTertiaryTable {
         1 outOf 10 weight "obj.sailing_veiled_kraken_ink_sac" count 1 condition { player ->
@@ -71,6 +74,3 @@ public val veiledKrakenDropTable: RSDropTable<Player, DropRollItem> = RSDropTabl
 )
 
 // Unknown wiki drop rates (text rarity — need data collection):
-//   - Camphor seed [main/1/{{#expr:1/(15/20 * 2/272) round 1}}]
-//   - Ironwood seed [main/1/{{#expr:1/(4/20 * 2/272) round 1}}]
-//   - Rosewood seed [main/1/{{#expr:1/(1/20 * 2/272) round 1}}]

--- a/content/drops/src/main/resources/drops/tables/monsters/demonic_gorilla.toml
+++ b/content/drops/src/main/resources/drops/tables/monsters/demonic_gorilla.toml
@@ -140,6 +140,42 @@ weight = 1
 obj = "obj.ballista_rope"
 count = 1
 
+[[main.separate_rolls]]
+numerator = 10
+denominator = 889
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.cert_unidentified_kwuarm"
+count = "7..13"
+
+[[main.separate_rolls]]
+numerator = 10
+denominator = 1111
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.cert_unidentified_cadantine"
+count = "7..13"
+
+[[main.separate_rolls]]
+numerator = 10
+denominator = 1481
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.cert_unidentified_lantadyme"
+count = "7..13"
+
+[[main.separate_rolls]]
+numerator = 10
+denominator = 1111
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.cert_unidentified_dwarf_weed"
+count = "7..13"
+
 [[tertiary]]
 numerator = 1
 denominator = 95
@@ -155,8 +191,4 @@ count = 1
 clue_scroll_box = true
 
 
-# Unknown wiki drop rate: Grimy kwuarm [main/Herbs/1/{{#expr:1/(40*{{#var:herbbase}}) round 1}}]
-# Unknown wiki drop rate: Grimy cadantine [main/Herbs/1/{{#expr:1/(32*{{#var:herbbase}}) round 1}}]
-# Unknown wiki drop rate: Grimy lantadyme [main/Herbs/1/{{#expr:1/(24*{{#var:herbbase}}) round 1}}]
-# Unknown wiki drop rate: Grimy dwarf weed [main/Herbs/1/{{#expr:1/(32*{{#var:herbbase}}) round 1}}]
 # Main table pool padding uses a nothing roll (F2P drops removed and/or subtable access missing from wiki parse) (46 weight)

--- a/content/drops/src/main/resources/drops/tables/monsters/dust_devil_drop_table_wilderness.toml
+++ b/content/drops/src/main/resources/drops/tables/monsters/dust_devil_drop_table_wilderness.toml
@@ -126,6 +126,15 @@ weight = 1
 obj = "obj.dust_battlestaff"
 count = 1
 
+[[main.separate_rolls]]
+numerator = 1
+denominator = 32256
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.dragon_chainbody"
+count = 1
+
 [[tertiary]]
 numerator = 1
 denominator = 3
@@ -134,6 +143,5 @@ count = 1
 should_drop_looting_bag = true
 
 
-# Unknown wiki drop rate: Dragon chainbody [main/Weapons and armour/1/{{#expr:126*256}}]
 # Unknown wiki drop rate: Nothing [main/Other/255/{{#expr:126*256}}]
 # Main table pool padding uses a nothing roll (F2P drops removed and/or subtable access missing from wiki parse) (1 weight)

--- a/content/drops/src/main/resources/drops/tables/monsters/guardian_drake.toml
+++ b/content/drops/src/main/resources/drops/tables/monsters/guardian_drake.toml
@@ -137,6 +137,78 @@ shared = "rareSeed"
 weight = 5
 nothing = true
 
+[[main.separate_rolls]]
+numerator = 5
+denominator = 496
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.unidentified_avantoe"
+count = "1..3"
+
+[[main.separate_rolls]]
+numerator = 5
+denominator = 496
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.unidentified_kwuarm"
+count = "1..3"
+
+[[main.separate_rolls]]
+numerator = 1
+denominator = 124
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.unidentified_ranarr"
+count = "1..3"
+
+[[main.separate_rolls]]
+numerator = 1
+denominator = 124
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.unidentified_snapdragon"
+count = "1..3"
+
+[[main.separate_rolls]]
+numerator = 1
+denominator = 124
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.unidentified_cadantine"
+count = "1..3"
+
+[[main.separate_rolls]]
+numerator = 1
+denominator = 124
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.unidentified_dwarf_weed"
+count = "1..3"
+
+[[main.separate_rolls]]
+numerator = 10
+denominator = 1653
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.unidentified_lantadyme"
+count = "1..3"
+
+[[main.separate_rolls]]
+numerator = 10
+denominator = 1653
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.unidentified_torstol"
+count = "1..3"
+
 [[tertiary]]
 numerator = 10
 denominator = 121
@@ -145,12 +217,4 @@ count = 1
 clue_scroll_box = true
 
 
-# Unknown wiki drop rate: Grimy avantoe [main/Herbs/1/{{#expr:1/(5*{{#var:herbbase}}) round 1}}]
-# Unknown wiki drop rate: Grimy kwuarm [main/Herbs/1/{{#expr:1/(5*{{#var:herbbase}}) round 1}}]
-# Unknown wiki drop rate: Grimy ranarr weed [main/Herbs/1/{{#expr:1/(4*{{#var:herbbase}}) round 1}}]
-# Unknown wiki drop rate: Grimy snapdragon [main/Herbs/1/{{#expr:1/(4*{{#var:herbbase}}) round 1}}]
-# Unknown wiki drop rate: Grimy cadantine [main/Herbs/1/{{#expr:1/(4*{{#var:herbbase}}) round 1}}]
-# Unknown wiki drop rate: Grimy dwarf weed [main/Herbs/1/{{#expr:1/(4*{{#var:herbbase}}) round 1}}]
-# Unknown wiki drop rate: Grimy lantadyme [main/Herbs/1/{{#expr:1/(3*{{#var:herbbase}}) round 1}}]
-# Unknown wiki drop rate: Grimy torstol [main/Herbs/1/{{#expr:1/(3*{{#var:herbbase}}) round 1}}]
 # Main table pool padding uses a nothing roll (F2P drops removed and/or subtable access missing from wiki parse) (5 weight)

--- a/content/drops/src/main/resources/drops/tables/monsters/lizardman_shaman.toml
+++ b/content/drops/src/main/resources/drops/tables/monsters/lizardman_shaman.toml
@@ -104,6 +104,42 @@ shared = "rareDrop"
 weight = 60
 nothing = true
 
+[[main.separate_rolls]]
+numerator = 25
+denominator = 889
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.unidentified_kwuarm"
+count = "2..3"
+
+[[main.separate_rolls]]
+numerator = 25
+denominator = 1111
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.unidentified_cadantine"
+count = "2..3"
+
+[[main.separate_rolls]]
+numerator = 25
+denominator = 1111
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.unidentified_dwarf_weed"
+count = "2..3"
+
+[[main.separate_rolls]]
+numerator = 50
+denominator = 2963
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.unidentified_lantadyme"
+count = "2..3"
+
 [[tertiary]]
 numerator = 1
 denominator = 400
@@ -131,8 +167,4 @@ count = 1
 clue_scroll_box = true
 
 
-# Unknown wiki drop rate: Grimy kwuarm [main/Herbs/1/{{#expr:1/(5*{{#var:uht}}) round 2}}]
-# Unknown wiki drop rate: Grimy cadantine [main/Herbs/1/{{#expr:1/(4*{{#var:uht}}) round 2}}]
-# Unknown wiki drop rate: Grimy dwarf weed [main/Herbs/1/{{#expr:1/(4*{{#var:uht}}) round 2}}]
-# Unknown wiki drop rate: Grimy lantadyme [main/Herbs/1/{{#expr:1/(3*{{#var:uht}}) round 2}}]
 # Main table pool padding uses a nothing roll (F2P drops removed and/or subtable access missing from wiki parse) (60 weight)

--- a/content/drops/src/main/resources/drops/tables/monsters/longtailed_wyvern.toml
+++ b/content/drops/src/main/resources/drops/tables/monsters/longtailed_wyvern.toml
@@ -174,6 +174,186 @@ weight = 1
 obj = "obj.granite_boots"
 count = 1
 
+[[main.separate_rolls]]
+numerator = 10
+denominator = 437
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.unidentified_kwuarm"
+count = 2
+
+[[main.separate_rolls]]
+numerator = 10
+denominator = 547
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.unidentified_cadantine"
+count = 2
+
+[[main.separate_rolls]]
+numerator = 10
+denominator = 547
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.unidentified_dwarf_weed"
+count = 2
+
+[[main.separate_rolls]]
+numerator = 10
+denominator = 729
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.unidentified_lantadyme"
+count = 2
+
+[[main.separate_rolls]]
+numerator = 1
+denominator = 58
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.ranarr_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 5
+denominator = 5491
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.snapdragon_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 10
+denominator = 13977
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.torstol_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 2
+denominator = 3075
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.watermelon_seed"
+count = 15
+
+[[main.separate_rolls]]
+numerator = 2
+denominator = 3075
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.willow_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 2
+denominator = 607
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.mahogany_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 10
+denominator = 17083
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.maple_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 2
+denominator = 333
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.teak_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 10
+denominator = 1147
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.yew_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 5
+denominator = 10982
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.papaya_tree_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 2
+denominator = 5125
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.magic_tree_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 1
+denominator = 3075
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.palm_tree_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 5
+denominator = 19219
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.spirit_tree_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 1
+denominator = 5125
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.dragonfruit_tree_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 2
+denominator = 15375
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.celastrus_tree_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 2
+denominator = 15375
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.redwood_tree_seed"
+count = 1
+
 [[tertiary]]
 numerator = 1
 denominator = 12000
@@ -188,24 +368,4 @@ count = 1
 clue_scroll_box = true
 
 
-# Unknown wiki drop rate: Grimy kwuarm [main/Herbs/1/{{#expr:1/(40*{{#var:herbbase}}) round 1}}]
-# Unknown wiki drop rate: Grimy cadantine [main/Herbs/1/{{#expr:1/(32*{{#var:herbbase}}) round 1}}]
-# Unknown wiki drop rate: Grimy dwarf weed [main/Herbs/1/{{#expr:1/(32*{{#var:herbbase}}) round 1}}]
-# Unknown wiki drop rate: Grimy lantadyme [main/Herbs/1/{{#expr:1/(24*{{#var:herbbase}}) round 1}}]
-# Unknown wiki drop rate: Ranarr seed [main/Seeds/1/{{#expr:1/(15*{{#var:seedbase}} + 2/123) round 1}}]
-# Unknown wiki drop rate: Snapdragon seed [main/Seeds/1/{{#expr:1/(14*{{#var:seedbase}}) round 1}}]
-# Unknown wiki drop rate: Torstol seed [main/Seeds/1/{{#expr:1/(11*{{#var:seedbase}}) round 1}}]
-# Unknown wiki drop rate: Watermelon seed [main/Seeds/1/{{#expr:1/(10*{{#var:seedbase}}) round 1}}]
-# Unknown wiki drop rate: Willow seed [main/Seeds/1/{{#expr:1/(10*{{#var:seedbase}}) round 1}}]
-# Unknown wiki drop rate: Mahogany seed [main/Seeds/1/{{#expr:1/(9*{{#var:seedbase}} + (1/123 * 1/3)) round 1}}]
-# Unknown wiki drop rate: Maple seed [main/Seeds/1/{{#expr:1/(9*{{#var:seedbase}}) round 1}}]
-# Unknown wiki drop rate: Teak seed [main/Seeds/1/{{#expr:1/(9*{{#var:seedbase}} + (1/123 * 2/3)) round 1}}]
-# Unknown wiki drop rate: Yew seed [main/Seeds/1/{{#expr:1/(9*{{#var:seedbase}} + 1/123) round 1}}]
-# Unknown wiki drop rate: Papaya tree seed [main/Seeds/1/{{#expr:1/(7*{{#var:seedbase}}) round 1}}]
-# Unknown wiki drop rate: Magic seed [main/Seeds/1/{{#expr:1/(6*{{#var:seedbase}}) round 1}}]
-# Unknown wiki drop rate: Palm tree seed [main/Seeds/1/{{#expr:1/(5*{{#var:seedbase}}) round 1}}]
-# Unknown wiki drop rate: Spirit seed [main/Seeds/1/{{#expr:1/(4*{{#var:seedbase}}) round 1}}]
-# Unknown wiki drop rate: Dragonfruit tree seed [main/Seeds/1/{{#expr:1/(3*{{#var:seedbase}}) round 1}}]
-# Unknown wiki drop rate: Celastrus seed [main/Seeds/1/{{#expr:1/(2*{{#var:seedbase}}) round 1}}]
-# Unknown wiki drop rate: Redwood tree seed [main/Seeds/1/{{#expr:1/(2*{{#var:seedbase}}) round 1}}]
 # Main table pool padding uses a nothing roll (F2P drops removed and/or subtable access missing from wiki parse) (14 weight)

--- a/content/drops/src/main/resources/drops/tables/monsters/magma_strykewyrm.toml
+++ b/content/drops/src/main/resources/drops/tables/monsters/magma_strykewyrm.toml
@@ -172,12 +172,60 @@ weight = 1
 obj = "obj.dragon_sheet"
 count = 1
 
+[[main.separate_rolls]]
+numerator = 5
+denominator = 471
 
-# Unknown wiki drop rate: Diamond bolt tips [main/Bolt tips/1/{{#expr:1/(5/128 * 25/92) round 1}}]
-# Unknown wiki drop rate: Emerald bolt tips [main/Bolt tips/1/{{#expr:1/(5/128 * 20/92) round 1}}]
-# Unknown wiki drop rate: Ruby bolt tips [main/Bolt tips/1/{{#expr:1/(5/128 * 20/92) round 1}}]
-# Unknown wiki drop rate: Dragonstone bolt tips [main/Bolt tips/1/{{#expr:1/(5/128 * 15/92) round 1}}]
-# Unknown wiki drop rate: Onyx bolt tips [main/Bolt tips/1/{{#expr:1/(5/128 * 7/92) round 1}}]
-# Unknown wiki drop rate: Sapphire bolt tips [main/Bolt tips/1/{{#expr:1/(5/128 * 5/92) round 1}}]
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.xbows_bolt_tips_diamond"
+count = "5..10"
+
+[[main.separate_rolls]]
+numerator = 5
+denominator = 589
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.xbows_bolt_tips_emerald"
+count = "5..10"
+
+[[main.separate_rolls]]
+numerator = 5
+denominator = 589
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.xbows_bolt_tips_ruby"
+count = "5..10"
+
+[[main.separate_rolls]]
+numerator = 1
+denominator = 157
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.xbows_bolt_tips_dragonstone"
+count = "5..10"
+
+[[main.separate_rolls]]
+numerator = 2
+denominator = 673
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.xbows_bolt_tips_onyx"
+count = "5..10"
+
+[[main.separate_rolls]]
+numerator = 1
+denominator = 471
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.xbows_bolt_tips_sapphire"
+count = "5..10"
+
+
 # Unknown wiki drop rate: Clue scroll (hard) [tertiary/Tertiary/Unknown]
 # Main table pool padding uses a nothing roll (F2P drops removed and/or subtable access missing from wiki parse) (5 weight)

--- a/content/drops/src/main/resources/drops/tables/monsters/spitting_wyvern.toml
+++ b/content/drops/src/main/resources/drops/tables/monsters/spitting_wyvern.toml
@@ -174,6 +174,186 @@ weight = 1
 obj = "obj.granite_boots"
 count = 1
 
+[[main.separate_rolls]]
+numerator = 10
+denominator = 437
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.unidentified_kwuarm"
+count = 2
+
+[[main.separate_rolls]]
+numerator = 10
+denominator = 547
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.unidentified_cadantine"
+count = 2
+
+[[main.separate_rolls]]
+numerator = 10
+denominator = 547
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.unidentified_dwarf_weed"
+count = 2
+
+[[main.separate_rolls]]
+numerator = 10
+denominator = 729
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.unidentified_lantadyme"
+count = 2
+
+[[main.separate_rolls]]
+numerator = 1
+denominator = 58
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.ranarr_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 5
+denominator = 5491
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.snapdragon_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 10
+denominator = 13977
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.torstol_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 2
+denominator = 3075
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.watermelon_seed"
+count = 15
+
+[[main.separate_rolls]]
+numerator = 2
+denominator = 3075
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.willow_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 2
+denominator = 607
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.mahogany_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 10
+denominator = 17083
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.maple_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 2
+denominator = 333
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.teak_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 10
+denominator = 1147
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.yew_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 5
+denominator = 10982
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.papaya_tree_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 2
+denominator = 5125
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.magic_tree_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 1
+denominator = 3075
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.palm_tree_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 5
+denominator = 19219
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.spirit_tree_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 1
+denominator = 5125
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.dragonfruit_tree_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 2
+denominator = 15375
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.celastrus_tree_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 2
+denominator = 15375
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.redwood_tree_seed"
+count = 1
+
 [[tertiary]]
 numerator = 1
 denominator = 12000
@@ -188,24 +368,4 @@ count = 1
 clue_scroll_box = true
 
 
-# Unknown wiki drop rate: Grimy kwuarm [main/Herbs/1/{{#expr:1/(40*{{#var:herbbase}}) round 1}}]
-# Unknown wiki drop rate: Grimy cadantine [main/Herbs/1/{{#expr:1/(32*{{#var:herbbase}}) round 1}}]
-# Unknown wiki drop rate: Grimy dwarf weed [main/Herbs/1/{{#expr:1/(32*{{#var:herbbase}}) round 1}}]
-# Unknown wiki drop rate: Grimy lantadyme [main/Herbs/1/{{#expr:1/(24*{{#var:herbbase}}) round 1}}]
-# Unknown wiki drop rate: Ranarr seed [main/Seeds/1/{{#expr:1/(15*{{#var:seedbase}} + 2/123) round 1}}]
-# Unknown wiki drop rate: Snapdragon seed [main/Seeds/1/{{#expr:1/(14*{{#var:seedbase}}) round 1}}]
-# Unknown wiki drop rate: Torstol seed [main/Seeds/1/{{#expr:1/(11*{{#var:seedbase}}) round 1}}]
-# Unknown wiki drop rate: Watermelon seed [main/Seeds/1/{{#expr:1/(10*{{#var:seedbase}}) round 1}}]
-# Unknown wiki drop rate: Willow seed [main/Seeds/1/{{#expr:1/(10*{{#var:seedbase}}) round 1}}]
-# Unknown wiki drop rate: Mahogany seed [main/Seeds/1/{{#expr:1/(9*{{#var:seedbase}} + (1/123 * 1/3)) round 1}}]
-# Unknown wiki drop rate: Maple seed [main/Seeds/1/{{#expr:1/(9*{{#var:seedbase}}) round 1}}]
-# Unknown wiki drop rate: Teak seed [main/Seeds/1/{{#expr:1/(9*{{#var:seedbase}} + (1/123 * 2/3)) round 1}}]
-# Unknown wiki drop rate: Yew seed [main/Seeds/1/{{#expr:1/(9*{{#var:seedbase}} + 1/123) round 1}}]
-# Unknown wiki drop rate: Papaya tree seed [main/Seeds/1/{{#expr:1/(7*{{#var:seedbase}}) round 1}}]
-# Unknown wiki drop rate: Magic seed [main/Seeds/1/{{#expr:1/(6*{{#var:seedbase}}) round 1}}]
-# Unknown wiki drop rate: Palm tree seed [main/Seeds/1/{{#expr:1/(5*{{#var:seedbase}}) round 1}}]
-# Unknown wiki drop rate: Spirit seed [main/Seeds/1/{{#expr:1/(4*{{#var:seedbase}}) round 1}}]
-# Unknown wiki drop rate: Dragonfruit tree seed [main/Seeds/1/{{#expr:1/(3*{{#var:seedbase}}) round 1}}]
-# Unknown wiki drop rate: Celastrus seed [main/Seeds/1/{{#expr:1/(2*{{#var:seedbase}}) round 1}}]
-# Unknown wiki drop rate: Redwood tree seed [main/Seeds/1/{{#expr:1/(2*{{#var:seedbase}}) round 1}}]
 # Main table pool padding uses a nothing roll (F2P drops removed and/or subtable access missing from wiki parse) (14 weight)

--- a/content/drops/src/main/resources/drops/tables/monsters/taloned_wyvern.toml
+++ b/content/drops/src/main/resources/drops/tables/monsters/taloned_wyvern.toml
@@ -174,6 +174,186 @@ weight = 1
 obj = "obj.granite_boots"
 count = 1
 
+[[main.separate_rolls]]
+numerator = 10
+denominator = 437
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.unidentified_kwuarm"
+count = 2
+
+[[main.separate_rolls]]
+numerator = 10
+denominator = 547
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.unidentified_cadantine"
+count = 2
+
+[[main.separate_rolls]]
+numerator = 10
+denominator = 547
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.unidentified_dwarf_weed"
+count = 2
+
+[[main.separate_rolls]]
+numerator = 10
+denominator = 729
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.unidentified_lantadyme"
+count = 2
+
+[[main.separate_rolls]]
+numerator = 1
+denominator = 58
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.ranarr_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 5
+denominator = 5491
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.snapdragon_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 10
+denominator = 13977
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.torstol_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 2
+denominator = 3075
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.watermelon_seed"
+count = 15
+
+[[main.separate_rolls]]
+numerator = 2
+denominator = 3075
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.willow_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 2
+denominator = 607
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.mahogany_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 10
+denominator = 17083
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.maple_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 2
+denominator = 333
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.teak_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 10
+denominator = 1147
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.yew_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 5
+denominator = 10982
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.papaya_tree_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 2
+denominator = 5125
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.magic_tree_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 1
+denominator = 3075
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.palm_tree_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 5
+denominator = 19219
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.spirit_tree_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 1
+denominator = 5125
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.dragonfruit_tree_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 2
+denominator = 15375
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.celastrus_tree_seed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 2
+denominator = 15375
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.redwood_tree_seed"
+count = 1
+
 [[tertiary]]
 numerator = 1
 denominator = 12000
@@ -188,24 +368,4 @@ count = 1
 clue_scroll_box = true
 
 
-# Unknown wiki drop rate: Grimy kwuarm [main/Herbs/1/{{#expr:1/(40*{{#var:herbbase}}) round 1}}]
-# Unknown wiki drop rate: Grimy cadantine [main/Herbs/1/{{#expr:1/(32*{{#var:herbbase}}) round 1}}]
-# Unknown wiki drop rate: Grimy dwarf weed [main/Herbs/1/{{#expr:1/(32*{{#var:herbbase}}) round 1}}]
-# Unknown wiki drop rate: Grimy lantadyme [main/Herbs/1/{{#expr:1/(24*{{#var:herbbase}}) round 1}}]
-# Unknown wiki drop rate: Ranarr seed [main/Seeds/1/{{#expr:1/(15*{{#var:seedbase}} + 2/123) round 1}}]
-# Unknown wiki drop rate: Snapdragon seed [main/Seeds/1/{{#expr:1/(14*{{#var:seedbase}}) round 1}}]
-# Unknown wiki drop rate: Torstol seed [main/Seeds/1/{{#expr:1/(11*{{#var:seedbase}}) round 1}}]
-# Unknown wiki drop rate: Watermelon seed [main/Seeds/1/{{#expr:1/(10*{{#var:seedbase}}) round 1}}]
-# Unknown wiki drop rate: Willow seed [main/Seeds/1/{{#expr:1/(10*{{#var:seedbase}}) round 1}}]
-# Unknown wiki drop rate: Mahogany seed [main/Seeds/1/{{#expr:1/(9*{{#var:seedbase}} + (1/123 * 1/3)) round 1}}]
-# Unknown wiki drop rate: Maple seed [main/Seeds/1/{{#expr:1/(9*{{#var:seedbase}}) round 1}}]
-# Unknown wiki drop rate: Teak seed [main/Seeds/1/{{#expr:1/(9*{{#var:seedbase}} + (1/123 * 2/3)) round 1}}]
-# Unknown wiki drop rate: Yew seed [main/Seeds/1/{{#expr:1/(9*{{#var:seedbase}} + 1/123) round 1}}]
-# Unknown wiki drop rate: Papaya tree seed [main/Seeds/1/{{#expr:1/(7*{{#var:seedbase}}) round 1}}]
-# Unknown wiki drop rate: Magic seed [main/Seeds/1/{{#expr:1/(6*{{#var:seedbase}}) round 1}}]
-# Unknown wiki drop rate: Palm tree seed [main/Seeds/1/{{#expr:1/(5*{{#var:seedbase}}) round 1}}]
-# Unknown wiki drop rate: Spirit seed [main/Seeds/1/{{#expr:1/(4*{{#var:seedbase}}) round 1}}]
-# Unknown wiki drop rate: Dragonfruit tree seed [main/Seeds/1/{{#expr:1/(3*{{#var:seedbase}}) round 1}}]
-# Unknown wiki drop rate: Celastrus seed [main/Seeds/1/{{#expr:1/(2*{{#var:seedbase}}) round 1}}]
-# Unknown wiki drop rate: Redwood tree seed [main/Seeds/1/{{#expr:1/(2*{{#var:seedbase}}) round 1}}]
 # Main table pool padding uses a nothing roll (F2P drops removed and/or subtable access missing from wiki parse) (14 weight)

--- a/content/drops/src/main/resources/drops/tables/monsters/tortured_gorilla.toml
+++ b/content/drops/src/main/resources/drops/tables/monsters/tortured_gorilla.toml
@@ -129,6 +129,42 @@ weight = 1
 obj = "obj.ballista_rope"
 count = 1
 
+[[main.separate_rolls]]
+numerator = 2
+denominator = 105
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.cert_unidentified_kwuarm"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 5
+denominator = 328
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.cert_unidentified_cadantine"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 5
+denominator = 328
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.cert_unidentified_dwarf_weed"
+count = 1
+
+[[main.separate_rolls]]
+numerator = 5
+denominator = 437
+
+[[main.separate_rolls.entries]]
+weight = 1
+obj = "obj.cert_unidentified_lantadyme"
+count = 1
+
 [[tertiary]]
 numerator = 1
 denominator = 400
@@ -156,8 +192,4 @@ count = 1
 clue_scroll_box = true
 
 
-# Unknown wiki drop rate: Grimy kwuarm [main/Herbs/1/{{#expr:1/(40*{{#var:herbbase}}) round 1}}]
-# Unknown wiki drop rate: Grimy cadantine [main/Herbs/1/{{#expr:1/(32*{{#var:herbbase}}) round 1}}]
-# Unknown wiki drop rate: Grimy dwarf weed [main/Herbs/1/{{#expr:1/(32*{{#var:herbbase}}) round 1}}]
-# Unknown wiki drop rate: Grimy lantadyme [main/Herbs/1/{{#expr:1/(24*{{#var:herbbase}}) round 1}}]
 # Main table pool padding uses a nothing roll (F2P drops removed and/or subtable access missing from wiki parse) (93 weight)

--- a/tools/wiki-dumping/build.gradle.kts
+++ b/tools/wiki-dumping/build.gradle.kts
@@ -41,6 +41,15 @@ tasks.register<JavaExec>("dumpNpcSpawns") {
     mainClass.set("org.rsmod.tools.wiki.dumping.NpcSpawnCsvDumperKt")
 }
 
+tasks.register<JavaExec>("fillUnknownDropRates") {
+    group = "application"
+    description =
+        "Fills 'Unknown wiki drop rate' markers in drop tables from the wiki Dropsline Bucket API"
+    classpath = sourceSets["main"].runtimeClasspath
+    mainClass.set("org.rsmod.tools.wiki.dumping.dropfill.UnknownDropRateFillerKt")
+    args("--root=${rootProject.projectDir.absolutePath}")
+}
+
 tasks.register<JavaExec>("dumpShops") {
     group = "application"
     description =

--- a/tools/wiki-dumping/src/main/kotlin/org/rsmod/tools/wiki/dumping/dropfill/BucketClient.kt
+++ b/tools/wiki-dumping/src/main/kotlin/org/rsmod/tools/wiki/dumping/dropfill/BucketClient.kt
@@ -1,0 +1,166 @@
+package org.rsmod.tools.wiki.dumping.dropfill
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.request.get
+import io.ktor.client.request.headers
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.encodeURLParameter
+import java.io.Closeable
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlinx.coroutines.delay
+
+/**
+ * Targeted client for the wiki's Bucket API, which serves post-template-expansion drop data as
+ * structured JSON — the same rows the wikitext `{{DropsLine}}` templates render, without the
+ * wikitext parsing.
+ *
+ * Cache-first: raw responses land in `<cacheDir>/<bucket>/<key>.json` so reruns and offline
+ * verification work without network. Responses are validated before the cache is written; schema
+ * drift throws rather than emitting partial data.
+ */
+class BucketClient(
+    private val cacheDir: Path,
+    private val offline: Boolean = false,
+) : Closeable {
+    private val mapper = ObjectMapper()
+    private val http by lazy {
+        HttpClient(CIO) {
+            install(HttpTimeout) {
+                requestTimeoutMillis = 30_000
+                connectTimeoutMillis = 10_000
+                socketTimeoutMillis = 30_000
+            }
+        }
+    }
+
+    override fun close() {
+        http.close()
+    }
+
+    suspend fun dropsForPage(page: String): List<DropsRow> {
+        val spaced = page.replace('_', ' ').replace("'", "\\'")
+        val query =
+            "bucket('dropsline').select('drop_json','page_name_sub')" +
+                ".where('page_name','$spaced').limit(5000).run()"
+        val json = fetch("dropsline", page, query)
+        val bucket = json.get("bucket")
+        check(bucket != null && bucket.isArray) {
+            "Dropsline response has no bucket array for $page"
+        }
+        return bucket.map { row ->
+            val dropJson = row.get("drop_json")
+            check(dropJson != null && dropJson.isTextual) {
+                "Dropsline row missing drop_json for $page — schema drift"
+            }
+            val drop = mapper.readTree(dropJson.asText())
+            val item = drop.get("Dropped item")
+            val rarity = drop.get("Rarity")
+            check(item != null && item.isTextual && rarity != null && rarity.isTextual) {
+                "drop_json missing \"Dropped item\"/\"Rarity\" for $page — schema drift"
+            }
+            val qtyLow = drop.get("Quantity Low")
+            val qtyHigh = drop.get("Quantity High")
+            check(qtyLow != null && qtyLow.isNumber && qtyHigh != null && qtyHigh.isNumber) {
+                "drop_json missing numeric \"Quantity Low\"/\"Quantity High\" for $page — schema drift"
+            }
+            DropsRow(
+                item = item.asText(),
+                rarity = rarity.asText(),
+                qtyLow = qtyLow.asInt(),
+                qtyHigh = qtyHigh.asInt(),
+                noted = drop.get("Drop Quantity")?.asText()?.contains("(noted)") == true,
+            )
+        }
+    }
+
+    /**
+     * The `infobox_item` bucket rows for a wiki page name: one row per infobox version, each with
+     * the version's exact item name and its ids (an array of strings; one version can carry several
+     * ids). The names let the resolver pick the version a drop row actually names when a page
+     * defines variants — e.g. "Dragon knife" vs "Dragon knife(p)".
+     */
+    suspend fun itemRowsForPageName(pageName: String): List<InfoboxItemRow> {
+        val escaped = pageName.replace("'", "\\'")
+        val query =
+            "bucket('infobox_item').select('item_id','item_name','page_name')" +
+                ".where('page_name','$escaped').limit(500).run()"
+        val json = fetch("infobox_item", pageName, query)
+        val bucket = json.get("bucket")
+        check(bucket != null && bucket.isArray) {
+            "infobox_item response has no bucket array for $pageName"
+        }
+        return bucket.map { row ->
+            val raw = row.get("item_id")
+            val values =
+                when {
+                    raw == null -> emptyList()
+                    raw.isArray -> raw.toList()
+                    else -> listOf(raw)
+                }
+            InfoboxItemRow(
+                itemName = row.get("item_name")?.takeIf { it.isTextual }?.asText(),
+                ids = values.mapNotNull { it.asText().toIntOrNull() }.distinct(),
+            )
+        }
+    }
+
+    private suspend fun fetch(bucket: String, key: String, query: String): JsonNode {
+        val dir = cacheDir.resolve(bucket)
+        val cachePath = dir.resolve(key.replace(Regex("[^A-Za-z0-9_-]"), "_") + ".json")
+        if (Files.exists(cachePath)) {
+            return mapper.readTree(Files.readString(cachePath))
+        }
+        if (offline) {
+            error("offline mode and no cache for $bucket/$key ($cachePath)")
+        }
+        Files.createDirectories(dir)
+        val url = "$API?action=bucket&format=json&query=${query.encodeURLParameter()}"
+        var lastError: Exception? = null
+        for (attempt in 0 until 3) {
+            delay(if (attempt == 0) THROTTLE_MILLIS else 4_000L * attempt)
+            try {
+                val response =
+                    http.get(url) { headers { append(HttpHeaders.UserAgent, USER_AGENT) } }
+                check(response.status.value in 200..299) {
+                    "HTTP ${response.status.value} for $key"
+                }
+                val text = response.bodyAsText()
+                val json = mapper.readTree(text)
+                check(json.get("bucket")?.isArray == true) { "no bucket array for $key" }
+                Files.writeString(cachePath, text)
+                return json
+            } catch (e: Exception) {
+                lastError = e
+            }
+        }
+        throw IllegalStateException(
+            "Bucket fetch failed for $bucket/$key after 3 attempts: ${lastError?.message}",
+            lastError,
+        )
+    }
+
+    companion object {
+        private const val THROTTLE_MILLIS = 1_000L
+        private const val API = "https://oldschool.runescape.wiki/api.php"
+        private const val USER_AGENT =
+            "OpenRune-wiki-dumping/0.1 (github.com/OpenRune/OpenRune-Server)"
+    }
+}
+
+/** One `infobox_item` version row: the version's exact item name and its ids. */
+data class InfoboxItemRow(val itemName: String?, val ids: List<Int>)
+
+data class DropsRow(
+    val item: String,
+    val rarity: String,
+    val qtyLow: Int,
+    val qtyHigh: Int,
+    /** The wiki marks noted drops inside "Drop Quantity", e.g. "7–13 (noted)". */
+    val noted: Boolean,
+)

--- a/tools/wiki-dumping/src/main/kotlin/org/rsmod/tools/wiki/dumping/dropfill/DropRateAnchors.kt
+++ b/tools/wiki-dumping/src/main/kotlin/org/rsmod/tools/wiki/dumping/dropfill/DropRateAnchors.kt
@@ -1,0 +1,143 @@
+package org.rsmod.tools.wiki.dumping.dropfill
+
+import java.nio.file.Path
+import kotlin.io.path.extension
+import kotlin.io.path.listDirectoryEntries
+import kotlin.io.path.name
+import kotlin.io.path.readText
+
+/**
+ * The dumper's own markers of drops it could not rate-resolve:
+ * - TOML tables carry `# Unknown wiki drop rate: <item> [<table>/<subsection>/<rarity>]`
+ * - Kotlin tables carry `// - <item> [<table>/<rarity>]`
+ *
+ * "Mechanical" anchors hold an un-evaluated `{{#expr}}` rate template; everything else (Common,
+ * Varies, refs) is editorial and left untouched.
+ */
+data class DropAnchor(
+    val file: Path,
+    val line: Int, // 1-based
+    val item: String,
+    val table: String,
+    /** TOML anchors only; Kotlin anchors carry no subsection. */
+    val subsection: String?,
+    val rarity: String,
+    val page: String,
+) {
+    val mechanical: Boolean
+        get() = rarity.isMechanicalRarity
+}
+
+/** A `_unknown_drop_rates.txt` row: wikiPage, item, section, subsection, rarity. */
+data class ManifestRow(
+    val page: String,
+    val item: String,
+    val section: String,
+    val subsection: String,
+    val rarity: String,
+) {
+    val mechanical: Boolean
+        get() = rarity.isMechanicalRarity
+}
+
+private val String.isMechanicalRarity: Boolean
+    get() = contains("{{#expr")
+
+object DropRateAnchors {
+    private val TOML_ANCHOR =
+        Regex("""^# Unknown wiki drop rate: (.+?) \[([^/]+)/([^/]+)/(.*)]\s*$""")
+    private val KT_ANCHOR = Regex("""^//   - (.+?) \[([^/]+)/(.*)]\s*$""")
+    private val TOML_ID = Regex("""^id = "(.+)"$""", RegexOption.MULTILINE)
+    private val KT_IDENTIFIER = Regex("""tableIdentifier = "(.+?)"""")
+
+    fun parseManifest(text: String): List<ManifestRow> =
+        text
+            .lineSequence()
+            .filter { it.isNotBlank() && !it.startsWith("#") }
+            .mapNotNull { line ->
+                val parts = line.split("\t")
+                if (parts.size < 5) {
+                    null
+                } else {
+                    ManifestRow(
+                        page = parts[0],
+                        item = parts[1],
+                        section = parts[2],
+                        subsection = parts[3],
+                        rarity = parts.drop(4).joinToString("\t"),
+                    )
+                }
+            }
+            .toList()
+
+    /**
+     * TOML `id` → wiki page: strip " Drops", underscore; longest-manifest-prefix fallback covers
+     * split tables like "Dust devil Regular".
+     */
+    fun derivePageFromToml(tomlText: String, manifestPages: Set<String>): String {
+        val id = TOML_ID.find(tomlText)?.groupValues?.get(1) ?: return ""
+        val name = id.removeSuffix(" Drops")
+        val candidate = name.replace(' ', '_')
+        if (candidate in manifestPages) {
+            return candidate
+        }
+        var best = ""
+        for (page in manifestPages) {
+            if (name.startsWith(page.replace('_', ' ')) && page.length > best.length) {
+                best = page
+            }
+        }
+        return best.ifEmpty { candidate }
+    }
+
+    fun derivePageFromKotlin(text: String): String {
+        val identifier = KT_IDENTIFIER.find(text)?.groupValues?.get(1) ?: return ""
+        return identifier.removeSuffix(" Drops").trim().replace(' ', '_')
+    }
+
+    fun scanTomlAnchors(monstersDir: Path, manifestPages: Set<String>): List<DropAnchor> =
+        scan(monstersDir, "toml") { file, text ->
+            val page = derivePageFromToml(text, manifestPages)
+            text.lines().mapIndexedNotNull { index, line ->
+                TOML_ANCHOR.matchEntire(line)?.let { match ->
+                    DropAnchor(
+                        file = file,
+                        line = index + 1,
+                        item = match.groupValues[1],
+                        table = match.groupValues[2],
+                        subsection = match.groupValues[3],
+                        rarity = match.groupValues[4],
+                        page = page,
+                    )
+                }
+            }
+        }
+
+    fun scanKotlinAnchors(tablesDir: Path): List<DropAnchor> =
+        scan(tablesDir, "kt") { file, text ->
+            val page = derivePageFromKotlin(text)
+            text.lines().mapIndexedNotNull { index, line ->
+                KT_ANCHOR.matchEntire(line)?.let { match ->
+                    DropAnchor(
+                        file = file,
+                        line = index + 1,
+                        item = match.groupValues[1],
+                        table = match.groupValues[2],
+                        subsection = null,
+                        rarity = match.groupValues[3],
+                        page = page,
+                    )
+                }
+            }
+        }
+
+    private fun scan(
+        dir: Path,
+        extension: String,
+        parse: (Path, String) -> List<DropAnchor>,
+    ): List<DropAnchor> =
+        dir.listDirectoryEntries()
+            .filter { it.extension == extension }
+            .sortedBy { it.name }
+            .flatMap { file -> parse(file, file.readText()) }
+}

--- a/tools/wiki-dumping/src/main/kotlin/org/rsmod/tools/wiki/dumping/dropfill/DropRateDecisions.kt
+++ b/tools/wiki-dumping/src/main/kotlin/org/rsmod/tools/wiki/dumping/dropfill/DropRateDecisions.kt
@@ -1,0 +1,365 @@
+package org.rsmod.tools.wiki.dumping.dropfill
+
+import dev.openrune.rscm.RSCM
+import dev.openrune.rscm.RSCMType
+import java.util.Locale
+import kotlin.math.abs
+
+/**
+ * One decision per mechanical anchor: fill it from Dropsline or quarantine it with a stated reason
+ * — never guess.
+ *
+ * TOML anchors carry a subsection and must agree with the dumper's `_unknown_drop_rates.txt`
+ * manifest row where one exists. Kotlin anchors carry no subsection, so the anchor's own rate
+ * template (with variables solved from the file's unambiguous rows) disambiguates instead. The
+ * template never supplies the emitted number — Dropsline does.
+ */
+data class FillDecision(
+    val anchor: DropAnchor,
+    val outcome: Outcome,
+    val reason: String? = null,
+    val fill: Fill? = null,
+    val sourceRarity: String? = null,
+    /**
+     * Set only on the "ambiguous rarities, no usable template expectation" quarantine — the one
+     * case where the anchor's own row is knowable by elimination once its siblings have matched.
+     */
+    val eliminable: Boolean = false,
+) {
+    enum class Outcome {
+        FILL,
+        QUARANTINE,
+    }
+}
+
+data class Fill(
+    val anchorLine: Int, // 1-based line of the anchor comment
+    val objSymbol: String,
+    val rate: RarityFraction,
+    val qtyLow: Int,
+    val qtyHigh: Int,
+)
+
+/**
+ * Wiki item name → `obj.*` gameval key. Names never map textually (gamevals keep historical names:
+ * "Grimy avantoe" is obj.unidentified_avantoe), so resolution goes name → item id (wiki
+ * `infobox_item` bucket) → symbol (reverse RSCM mapping). Any step that is not exactly 1:1 fails,
+ * and the caller quarantines. Noted drops use the `cert_` variant of the base symbol.
+ *
+ * A page defining several versions (the Dragon knife page carries the base knife and its three
+ * poisoned forms) is not ambiguous when exactly one version's item name matches the drop row's item
+ * text — the drop names the item the game actually rolls, and derived forms are player-made.
+ */
+class StrictObjResolver(private val itemRows: suspend (String) -> List<InfoboxItemRow>) {
+    sealed interface Result {
+        data class Ok(val symbol: String) : Result
+
+        data class Fail(val reason: String) : Result
+    }
+
+    suspend fun resolve(item: String, noted: Boolean): Result {
+        val rows = itemRows(item)
+        var ids = rows.flatMap { it.ids }.distinct()
+        if (ids.isEmpty()) {
+            return Result.Fail("no wiki item ids for \"$item\"")
+        }
+        if (ids.size > 1) {
+            val narrowed = narrowByItemName(rows, item)
+            if (narrowed.size != 1) {
+                return Result.Fail("ambiguous wiki ids for \"$item\": ${ids.joinToString(", ")}")
+            }
+            ids = narrowed
+        }
+        val name =
+            reverseObj(ids[0]) ?: return Result.Fail("no obj symbol for id ${ids[0]} (\"$item\")")
+        if (noted) {
+            val cert = "cert_$name"
+            if (!hasObjMapping(cert)) {
+                return Result.Fail("no cert (noted) obj symbol $cert for \"$item\"")
+            }
+            return Result.Ok("obj.$cert")
+        }
+        return Result.Ok("obj.$name")
+    }
+
+    private fun reverseObj(itemId: Int): String? {
+        val mapped =
+            runCatching { RSCM.getReverseMapping(RSCMType.OBJ, itemId) }
+                .getOrNull()
+                ?.trim()
+                .orEmpty()
+        if (mapped.isBlank() || mapped == "-1") {
+            return null
+        }
+        return mapped.removePrefix("obj.")
+    }
+
+    private fun hasObjMapping(name: String): Boolean =
+        runCatching {
+                RSCM.getRSCM("obj.$name")
+                true
+            }
+            .getOrDefault(false)
+
+    companion object {
+        /** Ids of the versions whose item name is exactly [item]; empty when none match. */
+        fun narrowByItemName(rows: List<InfoboxItemRow>, item: String): List<Int> =
+            rows.filter { it.itemName == item }.flatMap { it.ids }.distinct()
+    }
+}
+
+object DropRateDecisions {
+    private const val TOLERANCE = 0.005 // 0.5%
+
+    /**
+     * Candidate rows for an item, deduplicated on the REDUCED fraction plus quantity and notedness:
+     * the wiki writes the same probability more than one way ("1/181.3" vs "2/362.6"), and keying
+     * on text would treat those as rival candidates and quarantine a decidable case. The first
+     * spelling seen is kept, so reports cite what the wiki showed first.
+     */
+    private fun dedupCandidates(drops: List<DropsRow>, item: String): List<DropsRow> {
+        val seen = LinkedHashMap<String, DropsRow>()
+        for (row in drops) {
+            if (row.item != item) continue
+            val fraction = RarityFraction.parse(row.rarity) ?: continue
+            seen.putIfAbsent("${fraction.key}|${row.qtyLow}|${row.qtyHigh}|${row.noted}", row)
+        }
+        return seen.values.toList()
+    }
+
+    private fun formatExpected(expected: Double): String =
+        "1/" + String.format(Locale.ROOT, "%.2f", 1 / expected)
+
+    suspend fun decideToml(
+        anchor: DropAnchor,
+        manifest: List<ManifestRow>,
+        drops: List<DropsRow>,
+        resolver: StrictObjResolver,
+        vars: Map<String, Double>,
+    ): FillDecision {
+        fun quarantine(reason: String) =
+            FillDecision(anchor, FillDecision.Outcome.QUARANTINE, reason)
+
+        if (anchor.table != "main") {
+            return quarantine("anchor table \"${anchor.table}\" is not main")
+        }
+        val manifestRow =
+            manifest.find {
+                it.mechanical &&
+                    it.page == anchor.page &&
+                    it.item == anchor.item &&
+                    it.subsection == anchor.subsection
+            }
+        if (manifestRow != null && manifestRow.rarity != anchor.rarity) {
+            return quarantine(
+                "manifest rarity differs from anchor: ${manifestRow.rarity} vs ${anchor.rarity}"
+            )
+        }
+        if (drops.isEmpty()) {
+            // Distinct from "no numeric row": the whole page came back empty,
+            // which points at a page-name/transclusion problem, not missing data.
+            return quarantine("page returned 0 Dropsline rows")
+        }
+        var candidates = dedupCandidates(drops, anchor.item)
+        if (candidates.isEmpty()) {
+            return quarantine("no numeric Dropsline row for item")
+        }
+        if (candidates.map { RarityFraction.parse(it.rarity)!!.key }.toSet().size > 1) {
+            val expected =
+                WikiExpr.evaluate(anchor.rarity, vars)
+                    ?: return quarantine(
+                            "ambiguous Dropsline rarities: ${candidates.joinToString(" | ") { it.rarity }}"
+                        )
+                        .copy(eliminable = true)
+            val within =
+                candidates.filter {
+                    abs(RarityFraction.parse(it.rarity)!!.rate - expected) / expected <= TOLERANCE
+                }
+            if (within.size != 1) {
+                return quarantine(
+                    "template expectation ${formatExpected(expected)} matched ${within.size} of " +
+                        "${candidates.size} candidates: ${candidates.joinToString(" | ") { it.rarity }}"
+                )
+            }
+            candidates = within
+        }
+        if (candidates.size > 1) {
+            return quarantine(
+                "multiple quantity/notedness variants: " +
+                    candidates.joinToString(" | ") {
+                        "${it.qtyLow}..${it.qtyHigh}" + if (it.noted) " (noted)" else ""
+                    }
+            )
+        }
+        val row = candidates[0]
+        val symbol =
+            when (val resolved = resolver.resolve(anchor.item, row.noted)) {
+                is StrictObjResolver.Result.Fail -> return quarantine(resolved.reason)
+                is StrictObjResolver.Result.Ok -> resolved.symbol
+            }
+        return FillDecision(
+            anchor = anchor,
+            outcome = FillDecision.Outcome.FILL,
+            sourceRarity = row.rarity,
+            fill =
+                Fill(
+                    anchor.line,
+                    symbol,
+                    RarityFraction.parse(row.rarity)!!,
+                    row.qtyLow,
+                    row.qtyHigh,
+                ),
+        )
+    }
+
+    suspend fun decideKotlin(
+        anchor: DropAnchor,
+        drops: List<DropsRow>,
+        resolver: StrictObjResolver,
+        vars: Map<String, Double>,
+    ): FillDecision {
+        val expected = WikiExpr.evaluate(anchor.rarity, vars)
+
+        fun quarantine(reason: String) =
+            FillDecision(anchor, FillDecision.Outcome.QUARANTINE, reason)
+
+        if (anchor.table != "main") {
+            return quarantine("anchor table \"${anchor.table}\" is not main")
+        }
+        if (drops.isEmpty()) {
+            return quarantine("page returned 0 Dropsline rows")
+        }
+        val candidates = dedupCandidates(drops, anchor.item)
+        if (candidates.isEmpty()) {
+            return quarantine("no numeric Dropsline row for item")
+        }
+        val chosen: DropsRow
+        if (candidates.size == 1) {
+            chosen = candidates[0]
+            if (expected != null) {
+                val rate = RarityFraction.parse(chosen.rarity)!!.rate
+                if (abs(rate - expected) / expected > TOLERANCE) {
+                    return quarantine(
+                        "sole candidate ${chosen.rarity} disagrees with template expectation ${formatExpected(expected)}"
+                    )
+                }
+            }
+        } else {
+            if (expected == null) {
+                return quarantine(
+                        "ambiguous Dropsline rarities and no usable template expectation: " +
+                            candidates.joinToString(" | ") { it.rarity }
+                    )
+                    .copy(eliminable = true)
+            }
+            val within =
+                candidates.filter {
+                    abs(RarityFraction.parse(it.rarity)!!.rate - expected) / expected <= TOLERANCE
+                }
+            when {
+                within.isEmpty() ->
+                    return quarantine(
+                        "no candidate matches template expectation ${formatExpected(expected)}: " +
+                            candidates.joinToString(" | ") { it.rarity }
+                    )
+                within.size > 1 ->
+                    return quarantine(
+                        "template expectation matches ${within.size} candidates: " +
+                            within.joinToString(" | ") { it.rarity }
+                    )
+            }
+            chosen = within[0]
+        }
+        val symbol =
+            when (val resolved = resolver.resolve(anchor.item, chosen.noted)) {
+                is StrictObjResolver.Result.Fail -> return quarantine(resolved.reason)
+                is StrictObjResolver.Result.Ok -> resolved.symbol
+            }
+        return FillDecision(
+            anchor = anchor,
+            outcome = FillDecision.Outcome.FILL,
+            sourceRarity = chosen.rarity,
+            fill =
+                Fill(
+                    anchor.line,
+                    symbol,
+                    RarityFraction.parse(chosen.rarity)!!,
+                    chosen.qtyLow,
+                    chosen.qtyHigh,
+                ),
+        )
+    }
+
+    /**
+     * Per-file variable observations: an anchor contributes when its item has exactly one numeric
+     * candidate (by reduced fraction) and its template holds exactly one variable.
+     */
+    fun observations(
+        anchors: List<DropAnchor>,
+        drops: List<DropsRow>,
+    ): List<VariableSolver.Observation> =
+        anchors.mapNotNull { anchor ->
+            val fractions = LinkedHashMap<String, RarityFraction>()
+            for (row in drops) {
+                if (row.item != anchor.item) continue
+                val fraction = RarityFraction.parse(row.rarity) ?: continue
+                fractions.putIfAbsent(fraction.key, fraction)
+            }
+            val candidates = fractions.values.toList()
+            if (candidates.size == 1 && WikiExpr.variablesIn(anchor.rarity).size == 1) {
+                VariableSolver.Observation(anchor.rarity, candidates[0].rate)
+            } else {
+                null
+            }
+        }
+
+    fun solveFileVariables(anchors: List<DropAnchor>, drops: List<DropsRow>): Map<String, Double> {
+        val observed = observations(anchors, drops)
+        val vars = mutableMapOf<String, Double>()
+        for (name in anchors.flatMap { WikiExpr.variablesIn(it.rarity) }.distinct()) {
+            VariableSolver.solve(observed, name)?.let { vars[name] = it }
+        }
+        return vars
+    }
+
+    /**
+     * Second pass over one file's decisions: an item whose sibling anchors have each matched a
+     * distinct Dropsline candidate, leaving exactly one anchor and exactly one candidate, gets that
+     * candidate by elimination — the wiki lists the item once per table it sits on, so a
+     * fully-claimed row set identifies the leftover. Anything short of an exact pairing (two
+     * leftovers, an unclaimed extra candidate, a fill matching zero or two candidates) leaves the
+     * quarantine in place.
+     */
+    fun eliminateRemaining(
+        decisions: List<FillDecision>,
+        drops: List<DropsRow>,
+    ): Map<DropAnchor, DropsRow> {
+        val eliminated = mutableMapOf<DropAnchor, DropsRow>()
+        for ((item, group) in decisions.groupBy { it.anchor.item }) {
+            val leftovers =
+                group.filter { it.outcome == FillDecision.Outcome.QUARANTINE && it.eliminable }
+            if (leftovers.size != 1) {
+                continue
+            }
+            val fills = group.mapNotNull { it.fill }
+            val remaining = dedupCandidates(drops, item).toMutableList()
+            if (remaining.size != fills.size + 1) {
+                continue
+            }
+            val paired =
+                fills.all { fill ->
+                    val match =
+                        remaining.filter { row ->
+                            RarityFraction.parse(row.rarity)!!.key == fill.rate.key &&
+                                row.qtyLow == fill.qtyLow &&
+                                row.qtyHigh == fill.qtyHigh
+                        }
+                    match.size == 1 && remaining.remove(match[0])
+                }
+            if (paired && remaining.size == 1) {
+                eliminated[leftovers[0].anchor] = remaining[0]
+            }
+        }
+        return eliminated
+    }
+}

--- a/tools/wiki-dumping/src/main/kotlin/org/rsmod/tools/wiki/dumping/dropfill/DropRatePatcher.kt
+++ b/tools/wiki-dumping/src/main/kotlin/org/rsmod/tools/wiki/dumping/dropfill/DropRatePatcher.kt
@@ -1,0 +1,165 @@
+package org.rsmod.tools.wiki.dumping.dropfill
+
+/**
+ * Applies fills to a drop-table file's text, preserving every other byte.
+ * - TOML: emit `[[main.separate_rolls]]` blocks (the dumper's own form) directly after the last
+ *   existing main-path block; delete each filled anchor comment.
+ * - Kotlin: emit `N outOf D separate "obj.x" count n` lines at the end of the `mainTable =
+ *   rsPlayerWeightedTable(…) { … }` lambda; delete each filled anchor comment. Brace matching skips
+ *   string/char literals and both comment forms, since a naive count lands in the wrong place.
+ */
+object DropRatePatcher {
+    private fun renderTomlBlock(fill: Fill): String {
+        val count =
+            if (fill.qtyLow == fill.qtyHigh) "${fill.qtyLow}"
+            else "\"${fill.qtyLow}..${fill.qtyHigh}\""
+        return listOf(
+                "[[main.separate_rolls]]",
+                "numerator = ${fill.rate.numerator}",
+                "denominator = ${fill.rate.denominator}",
+                "",
+                "[[main.separate_rolls.entries]]",
+                "weight = 1",
+                "obj = \"${fill.objSymbol}\"",
+                "count = $count",
+            )
+            .joinToString("\n")
+    }
+
+    fun patchToml(text: String, fills: List<Fill>): String {
+        if (fills.isEmpty()) {
+            return text
+        }
+        val lines = text.split("\n")
+        var lastMainHeader = -1
+        for (i in lines.indices) {
+            if (lines[i].startsWith("[main]") || lines[i].startsWith("[[main.")) {
+                lastMainHeader = i
+            }
+        }
+        check(lastMainHeader != -1) { "no [main] section — refusing to patch" }
+        var end = lines.size
+        for (i in lastMainHeader + 1 until lines.size) {
+            if (lines[i].startsWith("[") || lines[i].startsWith("# Unknown wiki drop rate:")) {
+                end = i
+                break
+            }
+        }
+        while (end > 0 && lines[end - 1].isBlank()) {
+            end-- // insert before the blank gap that precedes the next section
+        }
+        val remove = fills.map { it.anchorLine - 1 }.toSet()
+        val insertion = fills.joinToString("\n") { "\n" + renderTomlBlock(it) }.split("\n")
+        val out = mutableListOf<String>()
+        for (i in 0..lines.size) {
+            if (i == end) {
+                out += insertion
+            }
+            if (i < lines.size && i !in remove) {
+                out += lines[i]
+            }
+        }
+        return out.joinToString("\n")
+    }
+
+    private fun renderKotlinLine(fill: Fill): String {
+        val count =
+            if (fill.qtyLow == fill.qtyHigh) "${fill.qtyLow}" else "${fill.qtyLow}..${fill.qtyHigh}"
+        return "        ${fill.rate.numerator} outOf ${fill.rate.denominator} separate \"${fill.objSymbol}\" count $count"
+    }
+
+    private data class Span(val open: Int, val close: Int)
+
+    private fun mainTableSpan(text: String): Span? {
+        val match =
+            Regex("""mainTable = rsPlayerWeightedTable\([^)]*\)\s*\{""").find(text) ?: return null
+        val open = match.range.last // index of the '{'
+        var depth = 0
+        var i = open
+        while (i < text.length) {
+            when {
+                text[i] == '"' -> {
+                    // string literal (handles escapes; triple-quoted strings do not occur here)
+                    i++
+                    while (i < text.length && text[i] != '"') {
+                        i += if (text[i] == '\\') 2 else 1
+                    }
+                    i++
+                }
+                text[i] == '\'' -> {
+                    i++
+                    while (i < text.length && text[i] != '\'') {
+                        i += if (text[i] == '\\') 2 else 1
+                    }
+                    i++
+                }
+                text[i] == '/' && text.getOrNull(i + 1) == '/' -> {
+                    while (i < text.length && text[i] != '\n') i++
+                }
+                text[i] == '/' && text.getOrNull(i + 1) == '*' -> {
+                    i += 2
+                    while (i < text.length && !(text[i] == '*' && text.getOrNull(i + 1) == '/')) i++
+                    i += 2
+                }
+                else -> {
+                    if (text[i] == '{') {
+                        depth++
+                    } else if (text[i] == '}') {
+                        depth--
+                        if (depth == 0) {
+                            return Span(open, i)
+                        }
+                    }
+                    i++
+                }
+            }
+        }
+        return null
+    }
+
+    fun patchKotlin(text: String, fills: List<Fill>): String {
+        if (fills.isEmpty()) {
+            return text
+        }
+        val span =
+            checkNotNull(mainTableSpan(text)) {
+                "no mainTable = rsPlayerWeightedTable(...) { ... } span — refusing to patch"
+            }
+        val lines = text.split("\n")
+        // Line index holding the main table's closing brace; the block is
+        // inserted immediately before it. Working in line-index space (rather
+        // than deleting by line content) means two byte-identical anchor
+        // comments cannot both be removed when only one was targeted.
+        val closeLine = text.substring(0, span.close).count { it == '\n' }
+        check(closeLine != 0) { "main table close brace on the first line — refusing to patch" }
+        val remove = fills.map { it.anchorLine - 1 }.toSet()
+        for (index in remove) {
+            check(index in lines.indices && lines[index].startsWith("//   - ")) {
+                "anchorLine ${index + 1} is not an anchor comment — refusing to patch"
+            }
+        }
+        val emitted = fills.map { renderKotlinLine(it) }
+        val out = mutableListOf<String>()
+        for (i in lines.indices) {
+            if (i == closeLine) {
+                out += emitted
+            }
+            if (i !in remove) {
+                out += lines[i]
+            }
+        }
+        val result = out.joinToString("\n")
+        check(out.size == lines.size) {
+            "line accounting off: ${lines.size} -> ${out.size} with ${fills.size} fills"
+        }
+        val patched =
+            checkNotNull(mainTableSpan(result)) { "patched file lost its main table span" }
+        for (fill in fills) {
+            val at = result.indexOf(renderKotlinLine(fill))
+            check(at in patched.open..patched.close) {
+                "inserted line for ${fill.objSymbol} fell outside the main table span"
+            }
+        }
+        return result
+    }
+}

--- a/tools/wiki-dumping/src/main/kotlin/org/rsmod/tools/wiki/dumping/dropfill/UnknownDropRateFiller.kt
+++ b/tools/wiki-dumping/src/main/kotlin/org/rsmod/tools/wiki/dumping/dropfill/UnknownDropRateFiller.kt
@@ -1,0 +1,245 @@
+package org.rsmod.tools.wiki.dumping.dropfill
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.exists
+import kotlin.io.path.name
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
+import kotlin.system.exitProcess
+import kotlinx.coroutines.runBlocking
+import org.rsmod.tools.wiki.dumping.GameValLoader
+
+/**
+ * Fills the dumper's `Unknown wiki drop rate` markers from the wiki's Dropsline Bucket API — the
+ * post-template-expansion form of the same `{{DropsLine}}` rows the wikitext parser reads, which
+ * carries numeric rarities where the wikitext shows an unexpanded `{{#expr}}` template.
+ *
+ * Every anchor is either filled with an exact fraction taken verbatim from Dropsline, or
+ * quarantined with a stated reason. Nothing is guessed: rate templates are evaluated only to
+ * *choose between* candidate rows, never to produce the emitted number.
+ *
+ *     ./gradlew :tools:wiki-dumping:fillUnknownDropRates
+ *     ./gradlew :tools:wiki-dumping:fillUnknownDropRates --args="--dry-run"
+ *
+ * Flags: --root=<tree> --cache=<dir> --report=<tsv> --offline --dry-run --quiet
+ */
+fun main(args: Array<String>) {
+    val flags = args.filter { it.startsWith("--") }
+    fun flagValue(name: String): String? =
+        flags.firstOrNull { it.startsWith("--$name=") }?.substringAfter("--$name=")
+
+    val root =
+        flagValue("root")?.let { Path.of(it) }
+            ?: GameValLoader.resolveRootOrNull()
+            ?: error("cannot locate repo root — pass --root=<tree>")
+    val cacheDir =
+        flagValue("cache")?.let { Path.of(it) } ?: root.resolve(".data/cache/wiki-dropfill")
+    val offline = "--offline" in flags
+    val dryRun = "--dry-run" in flags
+    val quiet = "--quiet" in flags
+
+    fun info(message: String) {
+        if (!quiet) println(message)
+    }
+
+    val tablesDir = root.resolve("content/drops/src/main/resources/drops/tables")
+    val monstersDir = tablesDir.resolve("monsters")
+    val kotlinDir =
+        root.resolve("content/drops/src/main/kotlin/org/rsmod/content/drops/tables/monsters")
+    val manifestFile = tablesDir.resolve("_unknown_drop_rates.txt")
+    check(monstersDir.exists() && kotlinDir.exists() && manifestFile.exists()) {
+        "drop-table tree not found under $root"
+    }
+
+    GameValLoader.ensureLoaded(root.absolutePathString())
+
+    val manifest = DropRateAnchors.parseManifest(manifestFile.readText())
+    val manifestPages = manifest.filter { it.mechanical }.map { it.page }.toSet()
+    val tomlAnchors =
+        DropRateAnchors.scanTomlAnchors(monstersDir, manifestPages).filter { it.mechanical }
+    val kotlinAnchors = DropRateAnchors.scanKotlinAnchors(kotlinDir).filter { it.mechanical }
+    info(
+        "fillUnknownDropRates: ${tomlAnchors.size} toml + ${kotlinAnchors.size} kotlin mechanical anchors"
+    )
+
+    val decisions = mutableListOf<FillDecision>()
+    val fetchFailures = mutableListOf<String>()
+
+    runBlocking {
+        BucketClient(cacheDir, offline).use { bucket ->
+            val itemRowCache = mutableMapOf<String, List<InfoboxItemRow>>()
+            val resolver = StrictObjResolver { item ->
+                itemRowCache.getOrPut(item) { bucket.itemRowsForPageName(item) }
+            }
+            // getOrPut cannot cache a null result, so failures are stored explicitly
+            // rather than re-fetched (and re-reported) for every file on the same page.
+            val dropsByPage = mutableMapOf<String, List<DropsRow>?>()
+            suspend fun dropsFor(page: String): List<DropsRow>? {
+                if (page in dropsByPage) {
+                    return dropsByPage[page]
+                }
+                val drops =
+                    try {
+                        bucket.dropsForPage(page)
+                    } catch (e: Exception) {
+                        fetchFailures += "fetch failed for $page: ${e.message}"
+                        null
+                    }
+                dropsByPage[page] = drops
+                return drops
+            }
+
+            suspend fun processFormat(
+                anchors: List<DropAnchor>,
+                decide: suspend (DropAnchor, List<DropsRow>, Map<String, Double>) -> FillDecision,
+                patch: (String, List<Fill>) -> String,
+            ) {
+                for ((file, fileAnchors) in anchors.groupBy { it.file }.toSortedMap()) {
+                    val page = fileAnchors[0].page
+                    if (page.isEmpty()) {
+                        decisions +=
+                            fileAnchors.map {
+                                FillDecision(
+                                    it,
+                                    FillDecision.Outcome.QUARANTINE,
+                                    "file has no derivable wiki page (no id field)",
+                                )
+                            }
+                        continue
+                    }
+                    val drops = dropsFor(page)
+                    if (drops == null) {
+                        // Do NOT fall through: the decision logic would report the page
+                        // as empty, which reads as "the wiki has no data" when the truth
+                        // is that we never got to ask.
+                        decisions +=
+                            fileAnchors.map {
+                                FillDecision(
+                                    it,
+                                    FillDecision.Outcome.QUARANTINE,
+                                    "Dropsline fetch failed for $page",
+                                )
+                            }
+                        continue
+                    }
+                    val vars = DropRateDecisions.solveFileVariables(fileAnchors, drops)
+                    var fileDecisions = fileAnchors.map { decide(it, drops, vars) }
+                    val eliminated = DropRateDecisions.eliminateRemaining(fileDecisions, drops)
+                    fileDecisions =
+                        fileDecisions.map { decision ->
+                            val row = eliminated[decision.anchor] ?: return@map decision
+                            when (
+                                val resolved = resolver.resolve(decision.anchor.item, row.noted)
+                            ) {
+                                is StrictObjResolver.Result.Fail -> decision
+                                is StrictObjResolver.Result.Ok ->
+                                    FillDecision(
+                                        anchor = decision.anchor,
+                                        outcome = FillDecision.Outcome.FILL,
+                                        reason = "by elimination: siblings matched every other row",
+                                        sourceRarity = row.rarity,
+                                        fill =
+                                            Fill(
+                                                decision.anchor.line,
+                                                resolved.symbol,
+                                                RarityFraction.parse(row.rarity)!!,
+                                                row.qtyLow,
+                                                row.qtyHigh,
+                                            ),
+                                    )
+                            }
+                        }
+                    decisions += fileDecisions
+                    val fills =
+                        fileDecisions
+                            .filter { it.outcome == FillDecision.Outcome.FILL }
+                            .map { it.fill!! }
+                    if (fills.isEmpty()) {
+                        continue
+                    }
+                    val patched = patch(file.readText(), fills)
+                    if (!dryRun) {
+                        file.writeText(patched)
+                    }
+                    info("  ${file.name}: ${fills.size} filled")
+                }
+            }
+
+            processFormat(
+                anchors = tomlAnchors,
+                decide = { anchor, drops, vars ->
+                    DropRateDecisions.decideToml(anchor, manifest, drops, resolver, vars)
+                },
+                patch = DropRatePatcher::patchToml,
+            )
+            processFormat(
+                anchors = kotlinAnchors,
+                decide = { anchor, drops, vars ->
+                    DropRateDecisions.decideKotlin(anchor, drops, resolver, vars)
+                },
+                patch = DropRatePatcher::patchKotlin,
+            )
+        }
+    }
+
+    val filled = decisions.filter { it.outcome == FillDecision.Outcome.FILL }
+    val quarantined = decisions.filter { it.outcome == FillDecision.Outcome.QUARANTINE }
+    val mechanical = tomlAnchors.size + kotlinAnchors.size
+    val reconciled = mechanical == filled.size + quarantined.size
+
+    info(
+        "filled ${filled.size}, quarantined ${quarantined.size} of $mechanical mechanical anchors" +
+            (if (dryRun) " (dry run — nothing written)" else "")
+    )
+    for (decision in quarantined) {
+        info(
+            "  quarantine ${decision.anchor.file.name}:${decision.anchor.line} ${decision.anchor.item} — ${decision.reason}"
+        )
+    }
+
+    flagValue("report")?.let { reportPath ->
+        val report = buildString {
+            appendLine(
+                "file\tline\titem\tpage\toutcome\tobj\tnumerator\tdenominator\tqtyLow\tqtyHigh\tsourceRarity\treason"
+            )
+            for (d in
+                decisions.sortedWith(compareBy({ it.anchor.file.name }, { it.anchor.line }))) {
+                appendLine(
+                    listOf(
+                            d.anchor.file.name,
+                            d.anchor.line,
+                            d.anchor.item,
+                            d.anchor.page,
+                            d.outcome.name,
+                            d.fill?.objSymbol ?: "",
+                            d.fill?.rate?.numerator ?: "",
+                            d.fill?.rate?.denominator ?: "",
+                            d.fill?.qtyLow ?: "",
+                            d.fill?.qtyHigh ?: "",
+                            d.sourceRarity ?: "",
+                            d.reason ?: "",
+                        )
+                        .joinToString("\t")
+                )
+            }
+        }
+        val path = Path.of(reportPath)
+        path.parent?.let(Files::createDirectories)
+        path.writeText(report)
+        info("report → $reportPath")
+    }
+
+    if (!reconciled) {
+        System.err.println(
+            "RECONCILIATION BROKEN: $mechanical != ${filled.size} + ${quarantined.size}"
+        )
+    }
+    if (fetchFailures.isNotEmpty()) {
+        fetchFailures.forEach { System.err.println("FETCH FAILURE: $it") }
+    }
+    if (!reconciled || fetchFailures.isNotEmpty()) {
+        exitProcess(1)
+    }
+}

--- a/tools/wiki-dumping/src/main/kotlin/org/rsmod/tools/wiki/dumping/dropfill/WikiRateMath.kt
+++ b/tools/wiki-dumping/src/main/kotlin/org/rsmod/tools/wiki/dumping/dropfill/WikiRateMath.kt
@@ -1,0 +1,285 @@
+package org.rsmod.tools.wiki.dumping.dropfill
+
+import java.math.BigDecimal
+import java.math.RoundingMode
+import kotlin.math.abs
+import kotlin.math.ln
+import kotlin.math.pow
+import kotlin.math.sqrt
+
+/**
+ * A wiki rarity ("1/181.1", "10/1,077") reduced to an exact integer fraction.
+ *
+ * Decimals are scaled by powers of ten and reduced by gcd; anything non-numeric returns null for
+ * the caller to quarantine. The reduced fraction must reproduce the source value within 0.1% — a
+ * defensive invariant that no realistic Dropsline input can trigger.
+ */
+data class RarityFraction(val numerator: Long, val denominator: Long) {
+    val rate: Double
+        get() = numerator.toDouble() / denominator.toDouble()
+
+    val key: String
+        get() = "$numerator/$denominator"
+
+    companion object {
+        private val PATTERN = Regex("""^(\d+(?:\.\d+)?)/(\d+(?:\.\d+)?)$""")
+
+        fun parse(rarity: String): RarityFraction? {
+            val match = PATTERN.matchEntire(rarity.trim().replace(",", "")) ?: return null
+            val (numText, denText) = match.destructured
+            val decimals =
+                maxOf(
+                    numText.substringAfter('.', "").length,
+                    denText.substringAfter('.', "").length,
+                )
+            val scale = 10.0.pow(decimals)
+            var num = Math.round(numText.toDouble() * scale)
+            var den = Math.round(denText.toDouble() * scale)
+            if (num <= 0 || den <= 0 || num > den) {
+                return null
+            }
+            val g = gcd(num, den)
+            num /= g
+            den /= g
+            val source = numText.toDouble() / denText.toDouble()
+            if (abs(num.toDouble() / den.toDouble() - source) / source > 0.001) {
+                return null
+            }
+            return RarityFraction(num, den)
+        }
+
+        private tailrec fun gcd(a: Long, b: Long): Long = if (b == 0L) a else gcd(b, a % b)
+    }
+}
+
+/**
+ * A minimal evaluator for the wiki's `1/{{#expr: … round N}}` drop-rate templates. Used ONLY to
+ * compute an expected rate for disambiguating candidate Dropsline rows — emitted numbers always
+ * come from Dropsline.
+ *
+ * Grammar: + - * / and parentheses over decimal literals, with `{{#var:NAME}}` placeholders
+ * substituted before parsing, and a trailing `round N` rounding half-up to N decimal places.
+ */
+object WikiExpr {
+    private val VAR_PATTERN = Regex("""\{\{#var:([a-z_]+)}}""")
+    private val EXPR_PATTERN = Regex("""^1/\{\{#expr:(.+?)}}$""", RegexOption.DOT_MATCHES_ALL)
+    private val ROUND_PATTERN = Regex("""\s+round\s+(\d+)\s*$""")
+
+    /** Real anchors all use `round 1`; anything above this is treated as unparseable. */
+    private const val MAX_ROUND_PLACES = 15
+
+    fun variablesIn(template: String): List<String> =
+        VAR_PATTERN.findAll(template).map { it.groupValues[1] }.distinct().toList()
+
+    fun evaluate(template: String, vars: Map<String, Double> = emptyMap()): Double? {
+        val match = EXPR_PATTERN.matchEntire(template) ?: return null
+        var body = match.groupValues[1]
+        var places: Int? = null
+        val round = ROUND_PATTERN.find(body)
+        if (round != null) {
+            places = round.groupValues[1].toIntOrNull()
+            if (places == null || places > MAX_ROUND_PLACES) {
+                return null
+            }
+            body = body.substring(0, round.range.first)
+        }
+        for (name in variablesIn(template)) {
+            val value = vars[name] ?: return null
+            // Plain-decimal form: Double.toString uses scientific notation below
+            // 1e-3, which the arithmetic grammar (digits and '.') cannot parse.
+            body =
+                body.replace("{{#var:$name}}", "(${BigDecimal(value.toString()).toPlainString()})")
+        }
+        if (body.contains("{{")) {
+            return null // an unsubstituted construct we do not understand
+        }
+        val denominator = Arith(body.trim()).parse() ?: return null
+        if (denominator <= 0) {
+            return null
+        }
+        val rounded =
+            if (places == null) denominator else roundHalfUp(denominator, places) ?: return null
+        return if (rounded > 0) 1 / rounded else null
+    }
+
+    /** Round half-up on the decimal value, matching MediaWiki's `{{#expr: … round N}}`. */
+    private fun roundHalfUp(value: Double, places: Int): Double? =
+        runCatching {
+                BigDecimal(value.toString())
+                    .movePointRight(places)
+                    .setScale(0, RoundingMode.HALF_UP)
+                    .movePointLeft(places)
+                    .toDouble()
+            }
+            .getOrNull()
+            ?.takeIf { it.isFinite() }
+
+    /** Recursive-descent over + - * / and parens. Returns null on any malformed input. */
+    private class Arith(private val src: String) {
+        private var pos = 0
+
+        fun parse(): Double? {
+            val value = expr()
+            ws()
+            return if (value != null && pos == src.length) value else null
+        }
+
+        private fun ws() {
+            while (pos < src.length && src[pos].isWhitespace()) pos++
+        }
+
+        private fun expr(): Double? {
+            var left = term() ?: return null
+            while (true) {
+                ws()
+                val op = src.getOrNull(pos)
+                if (op != '+' && op != '-') return left
+                pos++
+                val right = term() ?: return null
+                left = if (op == '+') left + right else left - right
+            }
+        }
+
+        private fun term(): Double? {
+            var left = factor() ?: return null
+            while (true) {
+                ws()
+                val op = src.getOrNull(pos)
+                if (op != '*' && op != '/') return left
+                pos++
+                val right = factor() ?: return null
+                if (op == '/' && right == 0.0) return null
+                left = if (op == '*') left * right else left / right
+            }
+        }
+
+        private fun factor(): Double? {
+            ws()
+            when (src.getOrNull(pos)) {
+                '(' -> {
+                    pos++
+                    val value = expr() ?: return null
+                    ws()
+                    if (src.getOrNull(pos) != ')') return null
+                    pos++
+                    return value
+                }
+                '-' -> {
+                    pos++
+                    val value = factor() ?: return null
+                    return -value
+                }
+            }
+            val start = pos
+            while (pos < src.length && (src[pos].isDigit() || src[pos] == '.')) pos++
+            if (pos == start) return null
+            val n = src.substring(start, pos).toDoubleOrNull() ?: return null
+            return if (n.isFinite()) n else null
+        }
+    }
+}
+
+/**
+ * Recovers a wiki template variable (herbbase, uncseed, …) from observed Dropsline rates for
+ * anchors in the same file. Each template is monotonic in its unknown over the plausible range, so
+ * a coarse log-scale scan plus a ternary refine converges. Used only for disambiguation.
+ */
+object VariableSolver {
+    fun solve(observations: List<Observation>, name: String): Double? {
+        val usable =
+            observations.filter {
+                val vars = WikiExpr.variablesIn(it.template)
+                vars.size == 1 && vars[0] == name
+            }
+        if (usable.isEmpty()) {
+            return null
+        }
+        fun error(candidate: Double): Double? {
+            var sum = 0.0
+            for (obs in usable) {
+                val predicted = WikiExpr.evaluate(obs.template, mapOf(name to candidate))
+                if (predicted == null || obs.rate <= 0) {
+                    return null
+                }
+                sum += abs(ln(predicted / obs.rate))
+            }
+            return sum
+        }
+
+        // Candidate starting points: each observation inverted exactly (the
+        // rounding steps inside the template make the error a staircase, so a
+        // fixed-grid scan can settle on a neighbouring plateau), plus a coarse
+        // log-scale grid as a fallback when inversion fails.
+        val candidates = mutableListOf<Double>()
+        for (obs in usable) {
+            invert(obs.template, name, obs.rate)?.let { candidates += it }
+        }
+        var exp = -9.0
+        while (exp <= 0.0) {
+            candidates += 10.0.pow(exp)
+            exp += 0.05
+        }
+        var best: Pair<Double, Double>? = null
+        for (v in candidates) {
+            val e = error(v)
+            if (e != null && (best == null || e < best.second)) {
+                best = v to e
+            }
+        }
+        val anchor = best?.first ?: return null
+        var lo = anchor / 1.2
+        var hi = anchor * 1.2
+        for (iteration in 0 until 200) {
+            val m1 = lo + (hi - lo) / 3
+            val m2 = hi - (hi - lo) / 3
+            val e1 = error(m1) ?: break
+            val e2 = error(m2) ?: break
+            if (e1 < e2) hi = m2 else lo = m1
+        }
+        val solved = (lo + hi) / 2
+        val err = error(solved)
+        // reject a "solution" that does not actually reproduce the observations
+        return if (err != null && err / usable.size < 0.02) solved else null
+    }
+
+    /**
+     * Finds v with `evaluate(template, {name: v}) == rate` by log-space bisection — the template
+     * denominator is monotonic in the variable over the plausible range. Lands inside the exact-fit
+     * plateau where one exists; returns null when the rate is not bracketed.
+     */
+    private fun invert(template: String, name: String, rate: Double): Double? {
+        fun predict(v: Double): Double? = WikiExpr.evaluate(template, mapOf(name to v))
+        var lo = 1e-9
+        var hi = 1.0
+        var predLo = predict(lo)
+        var predHi = predict(hi)
+        var guard = 0
+        while ((predLo == null || predHi == null) && guard++ < 20 && lo < hi) {
+            if (predLo == null) {
+                lo *= 3
+                predLo = predict(lo)
+            }
+            if (predHi == null) {
+                hi /= 3
+                predHi = predict(hi)
+            }
+        }
+        if (predLo == null || predHi == null || lo >= hi) return null
+        if (predLo == rate) return lo
+        if (predHi == rate) return hi
+        if ((predLo < rate) == (predHi < rate)) return null
+        val increasing = predHi > predLo
+        repeat(200) {
+            val mid = sqrt(lo * hi)
+            val predMid = predict(mid) ?: return null
+            when {
+                predMid == rate -> return mid
+                (predMid < rate) == increasing -> lo = mid
+                else -> hi = mid
+            }
+        }
+        return sqrt(lo * hi)
+    }
+
+    data class Observation(val template: String, val rate: Double)
+}

--- a/tools/wiki-dumping/src/test/kotlin/org/rsmod/tools/wiki/dumping/dropfill/DropRateEliminationTest.kt
+++ b/tools/wiki-dumping/src/test/kotlin/org/rsmod/tools/wiki/dumping/dropfill/DropRateEliminationTest.kt
@@ -1,0 +1,139 @@
+package org.rsmod.tools.wiki.dumping.dropfill
+
+import java.nio.file.Path
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class DropRateEliminationTest {
+    private val file = Path.of("ArmouredKrakenDropTable.kt")
+
+    private fun anchor(item: String, line: Int, rarity: String = "1/{{#expr:1 round 1}}") =
+        DropAnchor(
+            file = file,
+            line = line,
+            item = item,
+            table = "main",
+            subsection = null,
+            rarity = rarity,
+            page = "Armoured_kraken",
+        )
+
+    private fun row(
+        rarity: String,
+        qtyLow: Int = 1,
+        qtyHigh: Int = qtyLow,
+        item: String = "Snape grass seed",
+    ) = DropsRow(item = item, rarity = rarity, qtyLow = qtyLow, qtyHigh = qtyHigh, noted = false)
+
+    private fun filled(anchor: DropAnchor, rarity: String, qtyLow: Int = 1, qtyHigh: Int = qtyLow) =
+        FillDecision(
+            anchor = anchor,
+            outcome = FillDecision.Outcome.FILL,
+            sourceRarity = rarity,
+            fill =
+                Fill(
+                    anchorLine = anchor.line,
+                    objSymbol = "obj.snape_grass_seed",
+                    rate = RarityFraction.parse(rarity)!!,
+                    qtyLow = qtyLow,
+                    qtyHigh = qtyHigh,
+                ),
+        )
+
+    private fun quarantined(anchor: DropAnchor, eliminable: Boolean) =
+        FillDecision(
+            anchor = anchor,
+            outcome = FillDecision.Outcome.QUARANTINE,
+            reason = "ambiguous Dropsline rarities and no usable template expectation",
+            eliminable = eliminable,
+        )
+
+    @Test
+    fun `sole leftover anchor takes the sole unmatched candidate`() {
+        // The Armoured kraken shape: the page lists the seed twice, the uncseed
+        // anchor already matched 1/1,556 x1, and only the 1/810.7 x3 row remains.
+        val uncseed = anchor("Snape grass seed", line = 10)
+        val rareseed = anchor("Snape grass seed", line = 11)
+        val drops = listOf(row("1/810.7", qtyLow = 3), row("1/1,556", qtyLow = 1))
+        val decisions = listOf(filled(uncseed, "1/1,556"), quarantined(rareseed, eliminable = true))
+
+        val eliminated = DropRateDecisions.eliminateRemaining(decisions, drops)
+
+        assertEquals(setOf(rareseed), eliminated.keys)
+        assertEquals("1/810.7", eliminated[rareseed]?.rarity)
+        assertEquals(3, eliminated[rareseed]?.qtyLow)
+    }
+
+    @Test
+    fun `two leftover anchors cannot be paired`() {
+        val a = anchor("Snape grass seed", line = 10)
+        val b = anchor("Snape grass seed", line = 11)
+        val drops = listOf(row("1/810.7", qtyLow = 3), row("1/1,556", qtyLow = 1))
+        val decisions = listOf(quarantined(a, eliminable = true), quarantined(b, eliminable = true))
+
+        assertTrue(DropRateDecisions.eliminateRemaining(decisions, drops).isEmpty())
+    }
+
+    @Test
+    fun `an unclaimed extra candidate blocks elimination`() {
+        val uncseed = anchor("Snape grass seed", line = 10)
+        val rareseed = anchor("Snape grass seed", line = 11)
+        val drops =
+            listOf(row("1/810.7", qtyLow = 3), row("1/1,556", qtyLow = 1), row("1/50", qtyLow = 5))
+        val decisions = listOf(filled(uncseed, "1/1,556"), quarantined(rareseed, eliminable = true))
+
+        assertTrue(DropRateDecisions.eliminateRemaining(decisions, drops).isEmpty())
+    }
+
+    @Test
+    fun `non-eliminable quarantines are never filled`() {
+        val a = anchor("Snape grass seed", line = 10)
+        val b = anchor("Snape grass seed", line = 11)
+        val drops = listOf(row("1/810.7", qtyLow = 3), row("1/1,556", qtyLow = 1))
+        val decisions = listOf(filled(a, "1/1,556"), quarantined(b, eliminable = false))
+
+        assertTrue(DropRateDecisions.eliminateRemaining(decisions, drops).isEmpty())
+    }
+
+    @Test
+    fun `the same probability written two ways is one candidate`() {
+        val uncseed = anchor("Snape grass seed", line = 10)
+        val rareseed = anchor("Snape grass seed", line = 11)
+        // "10/8,107" reduces to the same fraction as "1/810.7".
+        val drops =
+            listOf(
+                row("1/810.7", qtyLow = 3),
+                row("10/8,107", qtyLow = 3),
+                row("1/1,556", qtyLow = 1),
+            )
+        val decisions = listOf(filled(uncseed, "1/1,556"), quarantined(rareseed, eliminable = true))
+
+        val eliminated = DropRateDecisions.eliminateRemaining(decisions, drops)
+
+        assertEquals("1/810.7", eliminated[rareseed]?.rarity)
+    }
+
+    @Test
+    fun `other items in the file do not interfere`() {
+        val seed = anchor("Snape grass seed", line = 10)
+        val other = anchor("Toadflax seed", line = 11)
+        val drops =
+            listOf(
+                row("1/810.7", qtyLow = 3),
+                row("1/1,556", qtyLow = 1),
+                row("1/59.5", item = "Toadflax seed"),
+            )
+        val decisions =
+            listOf(
+                filled(seed, "1/1,556"),
+                quarantined(anchor("Snape grass seed", line = 12), eliminable = true),
+                filled(other, "1/59.5"),
+            )
+
+        val eliminated = DropRateDecisions.eliminateRemaining(decisions, drops)
+
+        assertEquals(1, eliminated.size)
+        assertEquals("1/810.7", eliminated.values.single().rarity)
+    }
+}

--- a/tools/wiki-dumping/src/test/kotlin/org/rsmod/tools/wiki/dumping/dropfill/StrictObjResolverTest.kt
+++ b/tools/wiki-dumping/src/test/kotlin/org/rsmod/tools/wiki/dumping/dropfill/StrictObjResolverTest.kt
@@ -1,0 +1,59 @@
+package org.rsmod.tools.wiki.dumping.dropfill
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class StrictObjResolverTest {
+    // The Dragon knife page: four versions, only one of which is named exactly
+    // like the page — the drop row names the item that is actually dropped.
+    private val dragonKnife =
+        listOf(
+            InfoboxItemRow(itemName = "Dragon knife", ids = listOf(22804)),
+            InfoboxItemRow(itemName = "Dragon knife(p++)", ids = listOf(22810)),
+            InfoboxItemRow(itemName = "Dragon knife(p)", ids = listOf(22806)),
+            InfoboxItemRow(itemName = "Dragon knife(p+)", ids = listOf(22808)),
+        )
+
+    @Test
+    fun `exact item name selects the base version among variants`() {
+        assertEquals(listOf(22804), StrictObjResolver.narrowByItemName(dragonKnife, "Dragon knife"))
+    }
+
+    @Test
+    fun `no version named exactly like the item narrows to nothing`() {
+        assertEquals(
+            emptyList<Int>(),
+            StrictObjResolver.narrowByItemName(dragonKnife, "Dragon knife(kp)"),
+        )
+    }
+
+    @Test
+    fun `two versions sharing the exact name stay ambiguous`() {
+        val rows =
+            listOf(
+                InfoboxItemRow(itemName = "Coins", ids = listOf(995)),
+                InfoboxItemRow(itemName = "Coins", ids = listOf(996)),
+            )
+        assertEquals(listOf(995, 996), StrictObjResolver.narrowByItemName(rows, "Coins"))
+    }
+
+    @Test
+    fun `duplicate ids across exact-name rows collapse to one`() {
+        val rows =
+            listOf(
+                InfoboxItemRow(itemName = "Coins", ids = listOf(995)),
+                InfoboxItemRow(itemName = "Coins", ids = listOf(995)),
+            )
+        assertEquals(listOf(995), StrictObjResolver.narrowByItemName(rows, "Coins"))
+    }
+
+    @Test
+    fun `rows without an item name are ignored`() {
+        val rows =
+            listOf(
+                InfoboxItemRow(itemName = null, ids = listOf(1)),
+                InfoboxItemRow(itemName = "Bones", ids = listOf(526)),
+            )
+        assertEquals(listOf(526), StrictObjResolver.narrowByItemName(rows, "Bones"))
+    }
+}


### PR DESCRIPTION
The drop-table dumper leaves an `Unknown wiki drop rate` marker wherever the wiki shows an unexpanded `{{#expr}}` rate template instead of a number — 288 of them across the TOML and Kotlin tables, so drops like Alchemical Hydra's eye and fang currently don't exist at runtime. This adds a `fillUnknownDropRates` gradle task that resolves those markers from the wiki's Dropsline Bucket API, which serves the same `{{DropsLine}}` rows post-template-expansion, and a data commit applying the result: 245 rates filled, 43 quarantined with stated reasons, nothing guessed.

Rates are taken verbatim from Dropsline and reduced to exact fractions ("1/181.1" becomes `10 outOf 1811`). Rate templates are evaluated only to choose between candidate rows when a page lists an item more than once, never to produce the emitted number. Item names resolve strictly: wiki name to item id (`infobox_item` bucket) to gameval symbol via the reverse RSCM mapping, and any step that is not exactly 1:1 quarantines the row instead of guessing. Two narrow disambiguation steps keep decidable rows out of quarantine: a page that defines several item versions (Dragon knife and its poisoned forms) resolves to the version whose item name matches the drop row exactly, and an item the wiki lists at two rates takes the one remaining candidate once its sibling anchors have matched every other row — both unit-tested, anything short of an exact match stays quarantined. Output uses the dumper's own emission forms (`[[main.separate_rolls]]` blocks in TOML, `N outOf D separate` lines in Kotlin) and preserves every other byte of the files.

Re-running the task is a no-op, `--dry-run` and `--offline` are supported (bucket responses are cached under `.data/cache/wiki-dropfill/`), `:content:drops:compileKotlin` passes on the filled tree, and a 26-row sample of the filled rates, including every fill where the wiki listed two candidate rates, was hand-checked against the wiki.

```
./gradlew :tools:wiki-dumping:fillUnknownDropRates --args="--dry-run"
```
