### PR TITLE
fix: check out the fork repo in the gameval-conflicts workflow

### DIFF
--- a/.github/workflows/gameval-conflicts.yml
+++ b/.github/workflows/gameval-conflicts.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Every PR opened from a fork currently fails this check at checkout: actions/checkout resolves `ref` against the base repository unless `repository` is set, so the job dies with "A branch or tag with the name '…' could not be found" before the conflict script ever runs (see the gameval-conflicts check on #146, #148, #158, #159). Passing the head repo lets detection actually run, so clean fork PRs go green and conflicting ones fail for the real reason.

One caveat: the token on fork PRs is read-only, so the explanatory comment on a conflicting fork PR may still fail to post — the conflict is still reported through the failing check itself. The auto-fix push path already guards on same-repo and is unchanged.
