### PR TITLE
feat: bucket-backed live wiki source for the shop tools

### DIFF
--- a/tools/wiki-dumping/src/main/kotlin/org/rsmod/tools/wiki/dumping/ShopNameMapper.kt
+++ b/tools/wiki-dumping/src/main/kotlin/org/rsmod/tools/wiki/dumping/ShopNameMapper.kt
@@ -7,10 +7,13 @@ import kotlin.io.path.Path
 import kotlin.io.path.createDirectories
 import kotlin.io.path.writeText
 import kotlin.system.exitProcess
+import kotlinx.coroutines.runBlocking
 import org.rsmod.tools.wiki.dumping.wiki.ParsedWikiShopInfobox
 import org.rsmod.tools.wiki.dumping.wiki.WikiClient
 import org.rsmod.tools.wiki.dumping.wiki.WikiDumpStorePages
 import org.rsmod.tools.wiki.dumping.wiki.WikiShopInfoboxParser
+import org.rsmod.tools.wiki.dumping.wiki.bucket.BucketSource
+import org.rsmod.tools.wiki.dumping.wiki.bucket.ShopBuckets
 
 data class ShopMappingEntry(
     val id: Int,
@@ -18,10 +21,9 @@ data class ShopMappingEntry(
     /** When set, used instead of auto-matching against wiki shop names. */
     val wikiArticle: String? = null,
     /**
-     * Selects a store table within a multi-table wiki page.
-     * Format: `section|namenotes` — e.g. `food|0 Subquests`, `items|full`.
-     * Section is the wiki `==Stock==` subsection (`food` / `items`).
-     * Namenotes matches `{{StoreTableHead|namenotes=(...)}}` (parens omitted).
+     * Selects a store table within a multi-table wiki page. Format: `section|namenotes` — e.g.
+     * `food|0 Subquests`, `items|full`. Section is the wiki `==Stock==` subsection (`food` /
+     * `items`). Namenotes matches `{{StoreTableHead|namenotes=(...)}}` (parens omitted).
      */
     val wikiStore: String? = null,
 )
@@ -36,11 +38,20 @@ object ShopNameMapper {
 
     private fun exportCsv(args: Array<String>) {
         val quiet = args.contains("--quiet")
+        val offline = args.contains("--offline")
         val inputPath = args.firstOrNull { it.startsWith("--input=") }?.substringAfter('=')
         val outputPath =
             args.firstOrNull { it.startsWith("--output=") }?.substringAfter('=')
                 ?: inputPath
                 ?: DEFAULT_CSV_PATH
+        val wikiDumpDir = args.firstOrNull { it.startsWith("--wiki-dump=") }?.substringAfter('=')
+        val sourceFlag =
+            args
+                .firstOrNull { it.startsWith("--source=") }
+                ?.substringAfter('=')
+                ?.trim()
+                ?.lowercase()
+        val useBucket = resolveUseBucket(sourceFlag, wikiDumpDir)
 
         GameValLoader.ensureLoaded()
 
@@ -52,10 +63,15 @@ object ShopNameMapper {
         }
 
         val wikiShops =
-            WikiClient.open().use { wiki ->
-                WikiDumpStorePages
-                    .listShopInfoboxPages(wiki.wikiDumpStore())
-                    .sortedBy { it.pageTitle }
+            if (useBucket) {
+                val bucketSource = BucketSource(bucketCacheDir(rootDir = null), offline = offline)
+                runBlocking { ShopBuckets(bucketSource).listShops() }.sortedBy { it.pageTitle }
+            } else {
+                WikiClient.open(wikiDumpDir).use { wiki ->
+                    WikiDumpStorePages.listShopInfoboxPages(wiki.wikiDumpStore()).sortedBy {
+                        it.pageTitle
+                    }
+                }
             }
         val index = buildNameIndex(wikiShops)
 
@@ -68,7 +84,11 @@ object ShopNameMapper {
             }
         val mappedArticles =
             mappedRows
-                .mapNotNull { row -> stripWikiBrackets(row.wikiArticle).takeIf { it.isNotBlank() }?.let(::normalizeShopKey) }
+                .mapNotNull { row ->
+                    stripWikiBrackets(row.wikiArticle)
+                        .takeIf { it.isNotBlank() }
+                        ?.let(::normalizeShopKey)
+                }
                 .toSet()
 
         val wikiOnlyRows =
@@ -87,7 +107,7 @@ object ShopNameMapper {
         println()
         println(
             "Wrote ${rows.size} row(s) (${mappedRows.size} mapped, ${wikiOnlyRows.size} wiki-only, " +
-                "$resolvedWiki wiki matches) -> $csvOutput",
+                "$resolvedWiki wiki matches) -> $csvOutput"
         )
     }
 
@@ -99,8 +119,7 @@ object ShopNameMapper {
     )
 
     fun loadDumpableRowsFromCsv(csvPath: java.nio.file.Path): List<ShopCsvEntry> =
-        Files
-            .readAllLines(csvPath)
+        Files.readAllLines(csvPath)
             .asSequence()
             .dropWhile { it.startsWith("#") || it.startsWith("id,") || it.startsWith("inv,") }
             .mapNotNull { line -> parseCsvEntry(line) }
@@ -134,8 +153,7 @@ object ShopNameMapper {
     }
 
     fun loadMappingsFromCsv(csvPath: java.nio.file.Path): List<ShopMappingEntry> =
-        Files
-            .readAllLines(csvPath)
+        Files.readAllLines(csvPath)
             .asSequence()
             .dropWhile { it.startsWith("#") || it.startsWith("id,") || it.startsWith("inv,") }
             .mapNotNull { line -> parseMappingRow(line) }
@@ -236,7 +254,9 @@ object ShopNameMapper {
             .replace(Regex("['`]"), "")
             .replace(Regex("[^a-z0-9]+"), "")
 
-    fun buildNameIndex(shops: List<ParsedWikiShopInfobox>): Map<String, List<ParsedWikiShopInfobox>> {
+    fun buildNameIndex(
+        shops: List<ParsedWikiShopInfobox>
+    ): Map<String, List<ParsedWikiShopInfobox>> {
         val index = mutableMapOf<String, MutableList<ParsedWikiShopInfobox>>()
 
         fun add(key: String, shop: ParsedWikiShopInfobox) {
@@ -305,10 +325,7 @@ object ShopNameMapper {
 
     private fun resolveInvFullKey(id: Int, slug: String): String {
         val reversed =
-            runCatching { RSCM.getReverseMapping(RSCMType.INV, id) }
-                .getOrNull()
-                ?.trim()
-                .orEmpty()
+            runCatching { RSCM.getReverseMapping(RSCMType.INV, id) }.getOrNull()?.trim().orEmpty()
         if (reversed.isNotBlank() && reversed != "-1") {
             return if (reversed.contains('.')) reversed else "${RSCMType.INV.prefix}.$reversed"
         }
@@ -378,7 +395,8 @@ object ShopNameMapper {
 
     private fun hasInvMapping(fullKey: String): Boolean =
         runCatching {
-            RSCM.getRSCM(fullKey)
-            true
-        }.getOrDefault(false)
+                RSCM.getRSCM(fullKey)
+                true
+            }
+            .getOrDefault(false)
 }

--- a/tools/wiki-dumping/src/main/kotlin/org/rsmod/tools/wiki/dumping/ShopWikiDumper.kt
+++ b/tools/wiki-dumping/src/main/kotlin/org/rsmod/tools/wiki/dumping/ShopWikiDumper.kt
@@ -7,18 +7,56 @@ import kotlin.io.path.writeText
 import kotlin.system.exitProcess
 import kotlin.system.measureTimeMillis
 import kotlinx.coroutines.runBlocking
+import org.rsmod.tools.wiki.dumping.wiki.ParsedStoreLine
+import org.rsmod.tools.wiki.dumping.wiki.ParsedStoreTable
 import org.rsmod.tools.wiki.dumping.wiki.WikiClient
 import org.rsmod.tools.wiki.dumping.wiki.WikiShopInfoboxParser
 import org.rsmod.tools.wiki.dumping.wiki.WikiShopStoreParser
+import org.rsmod.tools.wiki.dumping.wiki.bucket.BucketSource
+import org.rsmod.tools.wiki.dumping.wiki.bucket.ItemVersion
+import org.rsmod.tools.wiki.dumping.wiki.bucket.ShopBuckets
 
-private const val DEFAULT_MAPPINGS_RELATIVE = "tools/wiki-dumping/src/main/resources/shopmappings.csv"
+private const val DEFAULT_MAPPINGS_RELATIVE =
+    "tools/wiki-dumping/src/main/resources/shopmappings.csv"
 private const val DEFAULT_OUTPUT_RELATIVE = ".data/raw-cache/server/shops"
 
-data class ResolvedShopStock(
-    val objKey: String,
-    val count: Int,
-    val restockCycles: Int,
-)
+/**
+ * `inv`s that bucket mode must skip outright rather than write wrong or partial stock for — each
+ * reason verified live 2026-08-17 against a full-corpus regeneration. These are structural gaps in
+ * what the wiki's Bucket API exposes, not matching bugs: no amount of selector/name-matching logic
+ * can recover the data because the bucket has zero (or ambiguous, indistinguishable) rows for it.
+ */
+private val BUCKET_UNSERVABLE_REASONS: Map<String, String> =
+    mapOf(
+        // bucket=No opt-out: the page's real {{StoreTableHead}} sets `bucket=No`, so the
+        // storeline bucket has zero rows for it under any query shape.
+        "aldarin_general_store" to "bucket=No opt-out on the page's StoreTableHead",
+        "darkruneshop_crap" to "bucket=No opt-out on the page's StoreTableHead",
+        "darkruneshop_uber" to "bucket=No opt-out on the page's StoreTableHead",
+        "mcannonshop" to
+            "bucket=No opt-out on the real cannon-parts table; only an unrelated hidden " +
+                "repair/buy-back table remains bucket-visible",
+        // Page renamed on the wiki (redirect): bucket's exact-match `where('page_name', ...)`
+        // can't follow it — dump-mode's live page fetch resolves the redirect, buckets can't.
+        // Follow-up: this one is CSV-fixable — drop the trailing period from magicshop's
+        // wikiArticle ("Betty's Magic Emporium.") so it matches the page's current, post-rename
+        // title ("Betty's Magic Emporium") directly instead of relying on redirect resolution.
+        "magicshop" to
+            "page renamed on wiki (redirect); bucket can't follow it, CSV article is stale",
+        // Stock documented as a {{plinkt}} wikitable, not {{StoreLine}} — invisible to the
+        // storeline bucket, which only ever sees StoreLine template invocations.
+        "hunting_customfurshop" to
+            "stock is a {{plinkt}} wikitable, not {{StoreLine}} — not in the bucket",
+        // Two StoreTableHead blocks on the same page share identical (blank) store_notes, so the
+        // storeline bucket's group-by-store_notes collapses them into one indistinguishable group.
+        "tzhaar_shop_rune" to
+            "two unnamed StoreTableHead tables collapse into one group in the bucket",
+        // CSV wiki_store selector text has no equivalent in the live page's store_notes.
+        "sophanem_cloth_store_updated" to
+            "CSV wiki_store selector text absent from the live page's store_notes",
+    )
+
+data class ResolvedShopStock(val objKey: String, val count: Int, val restockCycles: Int)
 
 data class ShopDumpResult(
     val inv: String,
@@ -27,42 +65,89 @@ data class ShopDumpResult(
     val stock: List<ResolvedShopStock>,
     val unresolvedItems: List<String>,
     val skippedReason: String? = null,
-    val table: org.rsmod.tools.wiki.dumping.wiki.ParsedStoreTable? = null,
+    val table: ParsedStoreTable? = null,
     val shopName: String? = null,
 )
 
 class ShopWikiDumper(
-    private val wiki: WikiClient,
+    private val wiki: WikiClient?,
     private val objLookup: ObjRscmLookup,
-    private val itemLookup: ItemWikiLookup,
+    private val itemLookup: ItemWikiLookup?,
     private val log: DropDumpLog,
+    private val buckets: ShopBuckets? = null,
+    /**
+     * Wiki article titles (stripped, as returned by [ShopNameMapper.stripWikiBrackets]) that also
+     * have a `_skillcape`/`_skillcape_trimmed` CSV row pointing at them. Bucket mode needs this to
+     * exclude skill-cape lines from a *base* (non-cape) row's table — see [dumpShop].
+     */
+    private val capeSiblingArticles: Set<String> = emptySet(),
 ) {
+    private var shopNamesByTitleCache: Map<String, String>? = null
+
+    private suspend fun shopNamesByTitle(): Map<String, String> {
+        shopNamesByTitleCache?.let {
+            return it
+        }
+        val map =
+            checkNotNull(buckets) { "bucket mode requires ShopBuckets" }
+                .listShops()
+                .associate { it.pageTitle to it.infoboxName }
+        shopNamesByTitleCache = map
+        return map
+    }
+
     suspend fun dumpShop(row: ShopNameMapper.ShopCsvEntry): ShopDumpResult {
         val resolvedRow = ShopSpecialHandlers.resolveRow(row)
         val wikiTitle = ShopNameMapper.stripWikiBrackets(resolvedRow.wikiArticle)
         if (wikiTitle.isBlank()) {
             return skipped(resolvedRow, "no wiki article")
         }
-
-        val source = runCatching { wiki.rawPageSource(wikiTitle) }.getOrNull()
-        if (source.isNullOrBlank()) {
-            return skipped(resolvedRow, "wiki page not found: $wikiTitle")
+        if (buckets != null) {
+            BUCKET_UNSERVABLE_REASONS[resolvedRow.inv]?.let { reason ->
+                return skipped(resolvedRow, "bucket source can't serve this shop: $reason")
+            }
         }
 
-        val shopName =
-            ShopSpecialHandlers.resolveShopDisplayName(
-                resolvedRow.inv,
-                WikiShopInfoboxParser.parseShopInfobox(wikiTitle, source)?.infoboxName,
-            )
+        val shopName: String?
+        val table: ParsedStoreTable?
 
-        val table =
-            WikiShopStoreParser.skillcapeTrimmed(resolvedRow.inv)?.let { trimmed ->
-                WikiShopStoreParser.parseSkillcapeShop(source, trimmed)
-            }
-                ?: WikiShopStoreParser.parseSelectedTable(
-                    source,
-                    resolvedRow.wikiStore.takeIf { it.isNotBlank() },
+        if (buckets != null) {
+            shopName =
+                ShopSpecialHandlers.resolveShopDisplayName(
+                    resolvedRow.inv,
+                    shopNamesByTitle()[wikiTitle],
                 )
+            val tables = buckets.storeTables(wikiTitle)
+            table =
+                WikiShopStoreParser.skillcapeTrimmed(resolvedRow.inv)?.let { trimmed ->
+                    selectSkillcapeFromBuckets(tables, trimmed)
+                }
+                    ?: buckets
+                        .selectTable(tables, resolvedRow.wikiStore.takeIf { it.isNotBlank() })
+                        ?.let { selected -> excludeCapeSiblingLines(wikiTitle, selected) }
+        } else {
+            val wikiClient = checkNotNull(wiki) { "dump mode requires a WikiClient" }
+            val source = runCatching { wikiClient.rawPageSource(wikiTitle) }.getOrNull()
+            if (source.isNullOrBlank()) {
+                return skipped(resolvedRow, "wiki page not found: $wikiTitle")
+            }
+
+            shopName =
+                ShopSpecialHandlers.resolveShopDisplayName(
+                    resolvedRow.inv,
+                    WikiShopInfoboxParser.parseShopInfobox(wikiTitle, source)?.infoboxName,
+                )
+
+            table =
+                WikiShopStoreParser.skillcapeTrimmed(resolvedRow.inv)?.let { trimmed ->
+                    WikiShopStoreParser.parseSkillcapeShop(source, trimmed)
+                }
+                    ?: WikiShopStoreParser.parseSelectedTable(
+                        source,
+                        resolvedRow.wikiStore.takeIf { it.isNotBlank() },
+                    )
+        }
+
         if (table == null || table.lines.isEmpty()) {
             return skipped(
                 resolvedRow,
@@ -70,20 +155,28 @@ class ShopWikiDumper(
             )
         }
 
-        val stockLines = table.lines.filter { ShopSpecialHandlers.shouldIncludeStockLine(resolvedRow, it.stock) }
+        val stockLines =
+            table.lines.filter { ShopSpecialHandlers.shouldIncludeStockLine(resolvedRow, it.stock) }
         if (stockLines.isEmpty()) {
             return skipped(resolvedRow, "no in-stock lines after filtering stock=0")
         }
 
-        itemLookup.prewarm(stockLines.flatMap { line -> listOfNotNull(line.name, line.lookupName) })
+        itemLookup?.prewarm(
+            stockLines.flatMap { line -> listOfNotNull(line.name, line.lookupName) }
+        )
 
         val stock = mutableListOf<ResolvedShopStock>()
         val unresolved = linkedSetOf<String>()
 
         for (line in stockLines) {
             val objKey =
-                objLookup.resolveWikiItem(itemLookup, line.name)
-                    ?: line.lookupName?.let { objLookup.resolveWikiItem(itemLookup, it) }
+                if (buckets != null) {
+                    resolveItemViaBuckets(buckets, line)
+                } else {
+                    val lookup = checkNotNull(itemLookup) { "dump mode requires an ItemWikiLookup" }
+                    objLookup.resolveWikiItem(lookup, line.name)
+                        ?: line.lookupName?.let { objLookup.resolveWikiItem(lookup, it) }
+                }
             if (objKey == null) {
                 unresolved += line.name
                 log.warn("${resolvedRow.inv} unresolved item '${line.name}'")
@@ -120,11 +213,181 @@ class ShopWikiDumper(
         )
     }
 
+    /**
+     * Bucket-mode item resolution when the wiki fallback ([ItemWikiLookup]) is unavailable: the
+     * wiki's `item_id` bucket for the store line's page title first (authoritative — mirrors
+     * [ObjRscmLookup]'s documented priority of a real wiki item id over name heuristics), then
+     * local heuristics. Verified live this ordering matters: "Skirt (blue)" on Agmundi Quality
+     * Clothes resolves correctly via its page's item id (`dwarf_skirt3`), but the local
+     * display-name heuristic guesses the wrong, unrelated `blue_skirt` key first if tried before
+     * it.
+     */
+    private suspend fun resolveItemViaBuckets(
+        buckets: ShopBuckets,
+        line: ParsedStoreLine,
+    ): String? {
+        resolveViaBucketItemPage(buckets, line.name)?.let {
+            return it
+        }
+        line.lookupName
+            ?.let { resolveViaBucketItemPage(buckets, it) }
+            ?.let {
+                return it
+            }
+        resolveViaItemVersions(buckets, line.name)?.let {
+            return it
+        }
+        line.lookupName
+            ?.let { resolveViaItemVersions(buckets, it) }
+            ?.let {
+                return it
+            }
+        objLookup.resolveByDisplayName(line.name)?.let {
+            return it
+        }
+        return line.lookupName?.let { objLookup.resolveByDisplayName(it) }
+    }
+
+    /**
+     * `name` may carry a trimmed-cape `(t)` suffix that is not itself a wiki page — untrimmed and
+     * trimmed cape variants share a single page (verified live: `item_id` for "Thieving cape"
+     * returns two ids, one per variant, while "Thieving cape(t)" has no page at all). Strip the
+     * suffix before querying. A page with more than one item id is only resolved when those ids are
+     * *exactly* a base/`_trimmed` obj-key pair — anything else (an unrelated multi-variant page, or
+     * a pair that isn't a base/trimmed relationship) is intentionally left unresolved rather than
+     * guessed at, since a wrong guess here silently mis-stocks a shop.
+     */
+    private suspend fun resolveViaBucketItemPage(buckets: ShopBuckets, name: String): String? {
+        val trimmed = name.trim().endsWith("(t)", ignoreCase = true)
+        val pageTitle = if (trimmed) name.trim().dropLast("(t)".length).trim() else name.trim()
+        val candidates = buckets.itemPageIds(pageTitle).mapNotNull { objLookup.toRscm(it) }
+
+        if (candidates.size == 1) {
+            return candidates.single()
+        }
+        if (candidates.size != 2) {
+            return null
+        }
+        val (first, second) = candidates
+        return when {
+            second == "${first}_trimmed" -> if (trimmed) second else first
+            first == "${second}_trimmed" -> if (trimmed) first else second
+            else -> null
+        }
+    }
+
+    /**
+     * Resolves items that [resolveViaBucketItemPage] can't — a shared wiki page with multiple
+     * dose/lit-state/etc versions — via `infobox_item`'s per-version rows, which is exactly the
+     * structured version of what dump-mode's [ItemWikiLookup] anchor resolution does. Never
+     * guesses: every step below only returns a result when it's unambiguous (exactly one distinct
+     * id).
+     *
+     * Tier 1 — exact item-name lookup ([ShopBuckets.itemVersionsByName]): `infobox_item` carries
+     * the literal per-version display name, so this handles every shape without needing to derive a
+     * base page title, including names that don't share a stem with their page at all — verified
+     * live for `Unlit torch` (page `Torch`), `Unlit bug lantern` (page `Bug lantern`), `Bronze
+     * spear(kp)` (page `Bronze spear`), `Antipoison(3)`/`Waterskin(4)` (dose pages), and suffixless
+     * multi-version names like `Karambwan vessel`/`Candle`.
+     *
+     * Tier 2 — parenthetical-suffix fallback ([ShopBuckets.itemVersions] on the base
+     * page + [ShopBuckets.matchVersionBySuffix]): for the rarer case where the exact item-name
+     * match misses (e.g. a formatting difference between the storeline's `sold_item` text and the
+     * infobox's `item_name`) but `Name(sfx)` still parses and the base page's `version_anchor`
+     * still matches the suffix.
+     */
+    private suspend fun resolveViaItemVersions(buckets: ShopBuckets, name: String): String? {
+        val trimmedName = name.trim()
+
+        resolveUnambiguousVersion(buckets, buckets.itemVersionsByName(trimmedName))?.let {
+            return it
+        }
+
+        val suffixMatch = Regex("""^(.+?)\s*\((.+)\)$""").find(trimmedName) ?: return null
+        val base = suffixMatch.groupValues[1].trim()
+        val suffix = suffixMatch.groupValues[2].trim()
+        val versions = buckets.itemVersions(base)
+        return buckets.matchVersionBySuffix(versions, suffix)?.id?.let { objLookup.toRscm(it) }
+    }
+
+    private fun resolveUnambiguousVersion(
+        buckets: ShopBuckets,
+        versions: List<ItemVersion>,
+    ): String? {
+        if (versions.isEmpty()) {
+            return null
+        }
+        val distinctIds = versions.map { it.id }.distinct()
+        if (distinctIds.size == 1) {
+            return objLookup.toRscm(distinctIds.single())
+        }
+        return buckets.defaultVersion(versions)?.id?.let { objLookup.toRscm(it) }
+    }
+
+    /**
+     * Mirrors [WikiShopStoreParser.parseSkillcapeShop]'s union semantics (regular stock + cape-only
+     * lines) using bucket-sourced tables. Unlike the wikitext version, the wiki's Bucket API does
+     * not split skill-cape lines into their own `store_notes` group — verified live against `Martin
+     * Thwait's Lost and Found.` and `Aubury's Rune Shop.`, both trimmed and untrimmed cape lines
+     * sit in the same table as the regular stock, every row's `store_notes` blank. So the cape line
+     * is instead identified by name (`"... cape"`, optionally `"... cape(t)"`) within the resolved
+     * base table, and only the requested trim variant is spliced back in alongside the regular
+     * stock.
+     */
+    private fun selectSkillcapeFromBuckets(
+        tables: List<ParsedStoreTable>,
+        trimmed: Boolean,
+    ): ParsedStoreTable? {
+        val baseTable =
+            tables.firstOrNull { !it.hiddenStock && it.lines.isNotEmpty() && it.nameNotes == null }
+                ?: tables.firstOrNull { !it.hiddenStock && it.lines.isNotEmpty() }
+                ?: return null
+
+        val (capeLines, regularLines) = baseTable.lines.partition { isCapeLine(it.name) }
+        val selectedCapeLines =
+            capeLines.filter { it.name.contains("(t)", ignoreCase = true) == trimmed }
+        if (selectedCapeLines.isEmpty()) {
+            return null
+        }
+
+        return baseTable.copy(lines = regularLines + selectedCapeLines)
+    }
+
+    private fun isCapeLine(name: String): Boolean {
+        val trimmedName = name.trim()
+        return trimmedName.endsWith("cape", ignoreCase = true) ||
+            trimmedName.endsWith("cape(t)", ignoreCase = true) ||
+            trimmedName.endsWith("cape (t)", ignoreCase = true)
+    }
+
+    /**
+     * Counterpart to [selectSkillcapeFromBuckets]: a *base* (non-`_skillcape`) row's table can be
+     * the exact same bucket-merged group a skillcape row would splice cape lines out of (bucket
+     * data never separates them by `store_notes` — see [selectSkillcapeFromBuckets]'s doc). The
+     * wikitext-mode dumper never has this problem because cape lines live in a separate `===Skill
+     * cape===` heading entirely outside the main stock table. Only applied when
+     * [capeSiblingArticles] confirms this page actually has a registered skillcape CSV row —
+     * unconditionally stripping any line named "... cape" would wrongly delete real stock from
+     * shops that legitimately sell ordinary capes (`Blue cape`, `Hunter's cape`, etc, confirmed
+     * live in the checked-in corpus).
+     */
+    private fun excludeCapeSiblingLines(
+        wikiTitle: String,
+        table: ParsedStoreTable,
+    ): ParsedStoreTable {
+        if (wikiTitle !in capeSiblingArticles) {
+            return table
+        }
+        return table.copy(lines = table.lines.filterNot { isCapeLine(it.name) })
+    }
+
     fun writeToml(result: ShopDumpResult, outputDir: Path): Path {
         val table = result.table ?: error("missing table for ${result.inv}")
         val output = outputDir.resolve("${result.inv}.toml")
         output.parent?.createDirectories()
-        output.writeText(formatToml(result.inv, result.shopName, table, result.stock, result.unresolvedItems))
+        output.writeText(
+            formatToml(result.inv, result.shopName, table, result.stock, result.unresolvedItems)
+        )
         return output
     }
 
@@ -141,52 +404,51 @@ class ShopWikiDumper(
     private fun formatToml(
         inv: String,
         shopName: String?,
-        table: org.rsmod.tools.wiki.dumping.wiki.ParsedStoreTable,
+        table: ParsedStoreTable,
         stock: List<ResolvedShopStock>,
         unresolved: List<String>,
-    ): String =
-        buildString {
-            appendLine("[[inventory]]")
-            appendLine("isServerOnly = true")
-            appendLine("id = \"inv.$inv\"")
-            shopName?.let { appendLine("name = \"${tomlEscape(it)}\"") }
+    ): String = buildString {
+        appendLine("[[inventory]]")
+        appendLine("isServerOnly = true")
+        appendLine("id = \"inv.$inv\"")
+        shopName?.let { appendLine("name = \"${tomlEscape(it)}\"") }
+        appendLine()
+        appendLine("scope = \"Shared\"")
+        appendLine("stack = \"Always\"")
+        appendLine()
+        table.sellMultiplier?.let { appendLine("sellMultiplier = $it") }
+        table.buyMultiplier?.let { appendLine("buyMultiplier = $it") }
+        table.delta?.let { appendLine("delta = $it") }
+        if (table.sellMultiplier != null || table.buyMultiplier != null || table.delta != null) {
             appendLine()
-            appendLine("scope = \"Shared\"")
-            appendLine("stack = \"Always\"")
-            appendLine()
-            table.sellMultiplier?.let { appendLine("sellMultiplier = $it") }
-            table.buyMultiplier?.let { appendLine("buyMultiplier = $it") }
-            table.delta?.let { appendLine("delta = $it") }
-            if (table.sellMultiplier != null || table.buyMultiplier != null || table.delta != null) {
-                appendLine()
-            }
-            appendLine("size = ${stock.size.coerceAtLeast(1)}")
-            appendLine()
-            appendLine("protect = false")
-            appendLine("runWeight = false")
-            appendLine("restock = true")
-            appendLine("allStock = false")
-            appendLine("placeholders = false")
-            appendLine()
+        }
+        appendLine("size = ${stock.size.coerceAtLeast(1)}")
+        appendLine()
+        appendLine("protect = false")
+        appendLine("runWeight = false")
+        appendLine("restock = true")
+        appendLine("allStock = false")
+        appendLine("placeholders = false")
+        appendLine()
 
-            for (unresolvedName in unresolved) {
-                appendLine("# unresolved: $unresolvedName")
-            }
-            if (unresolved.isNotEmpty()) {
-                appendLine()
-            }
-
-            for (line in stock) {
-                appendLine("[[inventory.stock]]")
-                appendLine("obj = \"${line.objKey}\"")
-                appendLine("count = ${line.count}")
-                appendLine("restockCycles = ${line.restockCycles}")
-                appendLine()
-            }
+        for (unresolvedName in unresolved) {
+            appendLine("# unresolved: $unresolvedName")
+        }
+        if (unresolved.isNotEmpty()) {
+            appendLine()
         }
 
-    private fun tomlEscape(value: String): String = value.replace("\\", "\\\\").replace("\"", "\\\"")
+        for (line in stock) {
+            appendLine("[[inventory.stock]]")
+            appendLine("obj = \"${line.objKey}\"")
+            appendLine("count = ${line.count}")
+            appendLine("restockCycles = ${line.restockCycles}")
+            appendLine()
+        }
+    }
 
+    private fun tomlEscape(value: String): String =
+        value.replace("\\", "\\\\").replace("\"", "\\\"")
 }
 
 private fun defaultOutputDir(rootDir: String?): Path {
@@ -199,16 +461,79 @@ private fun defaultMappingsPath(rootDir: String?): Path {
     return root?.resolve(DEFAULT_MAPPINGS_RELATIVE) ?: Path(DEFAULT_MAPPINGS_RELATIVE)
 }
 
+private const val BUCKET_CACHE_DIR = ".data/cache/wiki-live/bucket"
+
+/**
+ * `--source=auto|bucket|dump` selects where shop/item wikitext comes from. `auto` (the default)
+ * uses a local dump if [WikiClient.resolveDumpDirectory] resolves to an existing non-empty
+ * directory, otherwise falls back to the wiki's live Bucket API.
+ */
+internal fun resolveUseBucket(sourceFlag: String?, wikiDumpDir: String?): Boolean =
+    when (sourceFlag) {
+        null,
+        "auto" -> !dumpDirAvailable(wikiDumpDir)
+        "bucket" -> true
+        "dump" -> false
+        else -> error("invalid --source=$sourceFlag (expected one of: auto, bucket, dump)")
+    }
+
+private fun dumpDirAvailable(wikiDumpDir: String?): Boolean {
+    val dir = WikiClient.resolveDumpDirectory(wikiDumpDir)
+    return dir.isDirectory && dir.listFiles()?.isNotEmpty() == true
+}
+
+/**
+ * Anchors the bucket disk cache to the repo root, matching [defaultOutputDir] /
+ * [defaultMappingsPath].
+ */
+internal fun bucketCacheDir(rootDir: String?): Path {
+    val root = rootDir?.let { Path(it) } ?: GameValLoader.resolveRootOrNull()
+    return root?.resolve(BUCKET_CACHE_DIR) ?: Path(BUCKET_CACHE_DIR)
+}
+
+private suspend fun runDump(
+    dumper: ShopWikiDumper,
+    rows: List<ShopNameMapper.ShopCsvEntry>,
+    outputDir: Path,
+    log: DropDumpLog,
+) {
+    outputDir.createDirectories()
+
+    var written = 0
+    var skipped = 0
+
+    for (row in rows) {
+        val result = dumper.dumpShop(row)
+        if (result.skippedReason != null) {
+            skipped++
+            log.warn("${row.inv} skipped — ${result.skippedReason}")
+            continue
+        }
+        val out = dumper.writeToml(result, outputDir)
+        written++
+        log.info(
+            "${row.inv} -> $out (${result.stock.size} item(s), ${result.unresolvedItems.size} unresolved)"
+        )
+    }
+
+    println()
+    println("Wrote $written shop TOML file(s) to $outputDir ($skipped skipped)")
+}
+
 fun main(args: Array<String>) {
     val flags = args.filter { it.startsWith("-") }.toSet()
     val quiet = flags.contains("--quiet") || flags.contains("-q")
     val verbose = flags.contains("--verbose") || flags.contains("-v")
+    val offline = flags.contains("--offline")
     val limit = args.firstOrNull { it.startsWith("--limit=") }?.substringAfter('=')?.toIntOrNull()
     val invFilter = args.firstOrNull { it.startsWith("--inv=") }?.substringAfter('=')?.trim()
     val rootDir =
         flags.firstOrNull { it.startsWith("--root=") }?.substringAfter('=')
             ?: System.getProperty("RSPS_ROOT")
-    val wikiDumpDir = flags.firstOrNull { it.startsWith("--wiki-dump=") }?.substringAfter("--wiki-dump=")
+    val wikiDumpDir =
+        flags.firstOrNull { it.startsWith("--wiki-dump=") }?.substringAfter("--wiki-dump=")
+    val sourceFlag =
+        flags.firstOrNull { it.startsWith("--source=") }?.substringAfter('=')?.trim()?.lowercase()
     val mappingsPath =
         flags.firstOrNull { it.startsWith("--mappings=") }?.substringAfter('=')?.let { Path(it) }
             ?: defaultMappingsPath(rootDir)
@@ -216,52 +541,62 @@ fun main(args: Array<String>) {
         flags.firstOrNull { it.startsWith("--out-dir=") }?.substringAfter('=')?.let { Path(it) }
             ?: defaultOutputDir(rootDir)
     val log = DropDumpLog(quiet = quiet, verbose = verbose)
+    val useBucket = resolveUseBucket(sourceFlag, wikiDumpDir)
 
     runBlocking {
-        val elapsed =
-            measureTimeMillis {
-                GameValLoader.ensureLoaded(rootDir)
-                val rows =
-                    ShopNameMapper
-                        .loadDumpableRowsFromCsv(mappingsPath)
-                        .let { list ->
-                            when {
-                                invFilter.isNullOrBlank() -> list
-                                else -> list.filter { it.inv.equals(invFilter, ignoreCase = true) }
-                            }
+        val elapsed = measureTimeMillis {
+            GameValLoader.ensureLoaded(rootDir)
+            val allRows = ShopNameMapper.loadDumpableRowsFromCsv(mappingsPath)
+            val rows =
+                allRows
+                    .let { list ->
+                        when {
+                            invFilter.isNullOrBlank() -> list
+                            else -> list.filter { it.inv.equals(invFilter, ignoreCase = true) }
                         }
-                        .let { list -> if (limit != null) list.take(limit) else list }
-
-                if (rows.isEmpty()) {
-                    System.err.println("No dumpable shop rows found in $mappingsPath")
-                    exitProcess(1)
-                }
-
-                log.info("dumping ${rows.size} shop(s) -> $outputDir")
-
-                WikiClient.open(wikiDumpDir, onPageFetch = { title -> log.verbose("wiki: $title") }).use { wiki ->
-                    val dumper = ShopWikiDumper(wiki, ObjRscmLookup(), ItemWikiLookup(wiki, log), log)
-                    outputDir.createDirectories()
-
-                    var written = 0
-                    var skipped = 0
-
-                    for (row in rows) {
-                        val result = dumper.dumpShop(row)
-                        if (result.skippedReason != null) {
-                            skipped++
-                            log.warn("${row.inv} skipped — ${result.skippedReason}")
-                            continue
-                        }
-                        val out = dumper.writeToml(result, outputDir)
-                        written++
-                        log.info("${row.inv} -> $out (${result.stock.size} item(s), ${result.unresolvedItems.size} unresolved)")
                     }
+                    .let { list -> if (limit != null) list.take(limit) else list }
 
-                    println()
-                    println("Wrote $written shop TOML file(s) to $outputDir ($skipped skipped)")
-                }
+            if (rows.isEmpty()) {
+                System.err.println("No dumpable shop rows found in $mappingsPath")
+                exitProcess(1)
             }
+
+            log.info("dumping ${rows.size} shop(s) -> $outputDir")
+
+            if (useBucket) {
+                val bucketSource = BucketSource(bucketCacheDir(rootDir), offline = offline)
+                // Computed from the UNFILTERED CSV load, not `rows` — a `--inv=`/`--limit=`
+                // single-shop run must still see a base row's skillcape siblings even though
+                // those sibling rows themselves aren't part of this run's `rows`.
+                val capeSiblingArticles =
+                    allRows
+                        .filter { WikiShopStoreParser.skillcapeTrimmed(it.inv) != null }
+                        .map {
+                            ShopNameMapper.stripWikiBrackets(
+                                ShopSpecialHandlers.resolveRow(it).wikiArticle
+                            )
+                        }
+                        .toSet()
+                val dumper =
+                    ShopWikiDumper(
+                        wiki = null,
+                        objLookup = ObjRscmLookup(),
+                        itemLookup = null,
+                        log = log,
+                        buckets = ShopBuckets(bucketSource),
+                        capeSiblingArticles = capeSiblingArticles,
+                    )
+                runDump(dumper, rows, outputDir, log)
+            } else {
+                WikiClient.open(wikiDumpDir, onPageFetch = { title -> log.verbose("wiki: $title") })
+                    .use { wiki ->
+                        val dumper =
+                            ShopWikiDumper(wiki, ObjRscmLookup(), ItemWikiLookup(wiki, log), log)
+                        runDump(dumper, rows, outputDir, log)
+                    }
+            }
+        }
         log.info("done in ${elapsed}ms")
     }
 }

--- a/tools/wiki-dumping/src/main/kotlin/org/rsmod/tools/wiki/dumping/wiki/bucket/BucketSource.kt
+++ b/tools/wiki-dumping/src/main/kotlin/org/rsmod/tools/wiki/dumping/wiki/bucket/BucketSource.kt
@@ -1,0 +1,114 @@
+package org.rsmod.tools.wiki.dumping.wiki.bucket
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.request.get
+import io.ktor.client.request.headers
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.encodeURLParameter
+import java.io.Closeable
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlinx.coroutines.delay
+
+private const val API = "https://oldschool.runescape.wiki/api.php"
+private const val USER_AGENT =
+    "OpenRune-Server wiki-dumping (https://github.com/OpenRune/OpenRune-Server)"
+
+private val sharedHttp by lazy {
+    HttpClient(CIO) {
+        install(HttpTimeout) {
+            requestTimeoutMillis = 30_000
+            connectTimeoutMillis = 10_000
+            socketTimeoutMillis = 30_000
+        }
+    }
+}
+
+internal suspend fun ktorFetch(url: String): String =
+    sharedHttp.get(url) { headers { append(HttpHeaders.UserAgent, USER_AGENT) } }.bodyAsText()
+
+/**
+ * Generic client for the wiki's Bucket API (`action=bucket`): builds queries, pages via
+ * `.offset()`, caches concatenated row arrays on disk, and validates responses. Cache-first so
+ * reruns are offline-safe; `offline = true` forbids network entirely (replay verification).
+ */
+class BucketSource(
+    private val cacheDir: Path,
+    private val offline: Boolean = false,
+    private val throttleMillis: Long = 500,
+    private val fetch: suspend (String) -> String = ::ktorFetch,
+) : Closeable {
+    private val mapper = ObjectMapper()
+    private var lastRequest = 0L
+
+    override fun close() = Unit
+
+    suspend fun rows(
+        bucket: String,
+        select: List<String>,
+        where: Pair<String, String>? = null,
+        cacheKey: String,
+        limit: Int = 5000,
+    ): List<JsonNode> {
+        val cached = cacheFile(bucket, cacheKey)
+        if (Files.isRegularFile(cached)) {
+            return mapper.readTree(Files.readString(cached)).toList()
+        }
+        check(!offline) { "offline mode: no cached response for bucket=$bucket key=$cacheKey" }
+        val all = mutableListOf<JsonNode>()
+        var offset = 0
+        while (true) {
+            val page = fetchPage(bucket, select, where, limit, offset)
+            all += page
+            if (page.size < limit) break
+            offset += limit
+        }
+        Files.createDirectories(cached.parent)
+        Files.writeString(cached, mapper.writeValueAsString(all))
+        return all
+    }
+
+    private suspend fun fetchPage(
+        bucket: String,
+        select: List<String>,
+        where: Pair<String, String>?,
+        limit: Int,
+        offset: Int,
+    ): List<JsonNode> {
+        val selectArgs = select.joinToString(",") { "'$it'" }
+        val whereClause = where?.let { ".where('${it.first}','${escape(it.second)}')" } ?: ""
+        val query =
+            "bucket('$bucket').select($selectArgs)$whereClause.limit($limit).offset($offset).run()"
+        val url = "$API?action=bucket&format=json&query=${query.encodeURLParameter()}"
+        throttle()
+        val json = mapper.readTree(fetch(url))
+        json.get("error")?.let { error("bucket $bucket query failed: ${it.asText()}") }
+        val rows = json.get("bucket")
+        check(rows != null && rows.isArray) { "bucket $bucket: response has no bucket array" }
+        return rows.toList()
+    }
+
+    private suspend fun throttle() {
+        val since = System.currentTimeMillis() - lastRequest
+        if (since < throttleMillis) delay(throttleMillis - since)
+        lastRequest = System.currentTimeMillis()
+    }
+
+    private fun cacheFile(bucket: String, key: String): Path =
+        cacheDir.resolve(bucket).resolve(sanitize(key) + ".json")
+
+    private fun escape(value: String): String = value.replace("\\", "\\\\").replace("'", "\\'")
+
+    private fun sanitize(key: String): String = key.replace(Regex("[^A-Za-z0-9._-]"), "_")
+}
+
+fun JsonNode.requireText(field: String, context: String): String {
+    val node = get(field)
+    check(node != null && node.isTextual) { "$context: field '$field' missing or non-text" }
+    return node.asText()
+}

--- a/tools/wiki-dumping/src/main/kotlin/org/rsmod/tools/wiki/dumping/wiki/bucket/ShopBuckets.kt
+++ b/tools/wiki-dumping/src/main/kotlin/org/rsmod/tools/wiki/dumping/wiki/bucket/ShopBuckets.kt
@@ -1,0 +1,207 @@
+package org.rsmod.tools.wiki.dumping.wiki.bucket
+
+import org.rsmod.tools.wiki.dumping.wiki.ParsedStoreLine
+import org.rsmod.tools.wiki.dumping.wiki.ParsedStoreTable
+import org.rsmod.tools.wiki.dumping.wiki.ParsedWikiShopInfobox
+import org.rsmod.tools.wiki.dumping.wiki.WikiShopStoreParser
+
+/**
+ * One row of the `infobox_item` bucket's per-version item data, e.g. `Waterskin(3)` /
+ * `Antipoison(3)` / `Candle` each have one row per dose/lit-state/etc variant sharing a page.
+ */
+data class ItemVersion(
+    val name: String,
+    val id: Int,
+    val versionAnchor: String?,
+    val isDefault: Boolean,
+)
+
+/** Typed readers over the wiki's shop-related buckets, adapted to the existing parser types. */
+class ShopBuckets(private val source: BucketSource) {
+
+    suspend fun listShops(): List<ParsedWikiShopInfobox> =
+        source.rows("infobox_shop", listOf("page_name", "shop_name"), cacheKey = "all-shops").map {
+            row ->
+            val page = row.requireText("page_name", "infobox_shop")
+            val name = row.get("shop_name")?.takeIf { it.isTextual }?.asText().orEmpty()
+            ParsedWikiShopInfobox(
+                pageTitle = page,
+                rsName = null,
+                infoboxName = name.ifBlank { page },
+            )
+        }
+
+    suspend fun storeTables(pageTitle: String): List<ParsedStoreTable> {
+        val rows =
+            source.rows(
+                "storeline",
+                listOf(
+                    "sold_item",
+                    "store_stock",
+                    "restock_time",
+                    "store_sell_multiplier",
+                    "store_buy_multiplier",
+                    "store_delta",
+                    "store_currency",
+                    "store_notes",
+                ),
+                where = "page_name" to pageTitle,
+                cacheKey = pageTitle,
+            )
+        val grouped = LinkedHashMap<String, MutableList<ParsedStoreLine>>()
+        val heads = mutableMapOf<String, Triple<Int?, Int?, Int?>>()
+        for (row in rows) {
+            val notes = row.get("store_notes")?.takeIf { it.isTextual }?.asText().orEmpty()
+            val line =
+                ParsedStoreLine(
+                    name = row.requireText("sold_item", "storeline $pageTitle"),
+                    stock = row.get("store_stock")?.asText()?.toIntOrNull() ?: 0,
+                    restockCycles = row.get("restock_time")?.asText()?.toIntOrNull() ?: 100,
+                )
+            grouped.getOrPut(notes) { mutableListOf() }.add(line)
+            heads.putIfAbsent(
+                notes,
+                Triple(
+                    row.get("store_sell_multiplier")?.asText()?.toIntOrNull(),
+                    row.get("store_buy_multiplier")?.asText()?.toIntOrNull(),
+                    row.get("store_delta")?.asText()?.toIntOrNull(),
+                ),
+            )
+        }
+        return grouped.map { (notes, lines) ->
+            val (sell, buy, delta) = heads.getValue(notes)
+            ParsedStoreTable(
+                sellMultiplier = sell,
+                buyMultiplier = buy,
+                delta = delta,
+                nameNotes = notes.trim().removeSurrounding("(", ")").ifBlank { null },
+                lines = lines,
+            )
+        }
+    }
+
+    /**
+     * `selector` is the CSV `wiki_store` value, e.g. `blackjacks|Defensive` or `food|2 Subquests`.
+     * Bucket `store_notes` text doesn't follow one convention across shops — verified live: it's
+     * "Defensive blackjacks" (subkey before section, no comma) on Ali's Discount Wares, "food, 2
+     * Subquests" (section prefix, comma) on Culinaromancer's Chest, and just "desert gear" (no
+     * section at all) on the same Ali's Discount Wares page. So match in tiers: first require every
+     * `|`-separated fragment to appear in the notes (disambiguates pages like Culinaromancer's
+     * Chest that group a "food"-prefixed table and an unprefixed table under the same subkey text),
+     * then fall back to an exact match on the last fragment alone (the common case with no section
+     * prefix), then a fuzzy contains on it.
+     */
+    fun selectTable(tables: List<ParsedStoreTable>, selector: String?): ParsedStoreTable? {
+        val normalized = selector?.let { WikiShopStoreParser.normalizeNameNotes(it) }
+        if (normalized.isNullOrBlank() || normalized == "default") {
+            // Mirrors the wikitext parser's blank-selector fallback: first table in document order,
+            // regardless of namenotes — verified live against Baba Yaga's Magic Shop., where the
+            // *first* (post-quest, namenotes-tagged) table is the correct default and a naive
+            // "prefer the unnamed table" rule would wrongly pick the second, pre-quest one.
+            return tables.firstOrNull { it.lines.isNotEmpty() }
+        }
+        val fragments =
+            selector!!.split('|').map(WikiShopStoreParser::normalizeNameNotes).filter {
+                it.isNotBlank()
+            }
+        fun notesOf(table: ParsedStoreTable) =
+            WikiShopStoreParser.normalizeNameNotes(table.nameNotes.orEmpty())
+        val target = fragments.last()
+        return tables.firstOrNull {
+            notesOf(it).isNotBlank() && fragments.all(notesOf(it)::contains)
+        }
+            ?: tables.firstOrNull { notesOf(it) == target }
+            ?: tables.firstOrNull {
+                notesOf(it).isNotBlank() &&
+                    (notesOf(it).contains(target) || target.contains(notesOf(it)))
+            }
+    }
+
+    suspend fun itemPageIds(pageTitle: String): List<Int> =
+        source
+            .rows("item_id", listOf("id"), where = "page_name" to pageTitle, cacheKey = pageTitle)
+            .flatMap { row ->
+                val ids = row.get("id") ?: return@flatMap emptyList<Int>()
+                if (ids.isArray) ids.mapNotNull { it.asText().toIntOrNull() }
+                else listOfNotNull(ids.asText().toIntOrNull())
+            }
+
+    /**
+     * Per-version rows from `infobox_item` for a shared page — e.g. `Waterskin` has one row per
+     * dose (`version_anchor` `"(0)"`..`"(4)"`), `Antipoison` one per dose (`version_anchor` `"1
+     * dose"`..`"4 dose"`, note the different shape from Waterskin's), `Candle`/`Karambwan vessel`
+     * one per lit/empty state (`version_anchor` `"Unlit"`/`"Lit"`, `"Empty"`/`"Baited"`).
+     * `default_version` is a boolean field the Bucket API represents as key-present-with-empty-
+     * string for true, key-absent for false (verified live) — [ItemVersion.isDefault] reflects
+     * that. `item_id` is a repeated field like [itemPageIds]'s `id`.
+     */
+    suspend fun itemVersions(pageTitle: String): List<ItemVersion> =
+        itemVersionRows("page_name" to pageTitle, cacheKey = "page:$pageTitle")
+
+    /**
+     * Same per-version rows as [itemVersions], queried by the exact per-version **item name**
+     * instead of the page title — e.g. `Unlit torch`'s page is `Torch`, `Bronze spear(kp)`'s page
+     * is `Bronze spear`, neither derivable from the display name by stripping a suffix. Verified
+     * live this resolves those directly, and correctly filters out the odd non-game row
+     * `infobox_item` carries for some names (`Candle`'s `item_name` match includes a `"Candles
+     * (interface item)"` row whose `item_id` is the literal string `"interface8128"`, not a real
+     * item id — [itemVersions]'s `toIntOrNull()` parse naturally drops it).
+     */
+    suspend fun itemVersionsByName(itemName: String): List<ItemVersion> =
+        itemVersionRows("item_name" to itemName, cacheKey = "name:$itemName")
+
+    private suspend fun itemVersionRows(
+        where: Pair<String, String>,
+        cacheKey: String,
+    ): List<ItemVersion> =
+        source
+            .rows(
+                "infobox_item",
+                listOf("item_name", "item_id", "version_anchor", "default_version"),
+                where = where,
+                cacheKey = cacheKey,
+            )
+            .mapNotNull { row ->
+                val ids = row.get("item_id") ?: return@mapNotNull null
+                val id =
+                    (if (ids.isArray) ids.firstOrNull() else ids)?.asText()?.toIntOrNull()
+                        ?: return@mapNotNull null
+                ItemVersion(
+                    name = row.get("item_name")?.takeIf { it.isTextual }?.asText().orEmpty(),
+                    id = id,
+                    versionAnchor = row.get("version_anchor")?.takeIf { it.isTextual }?.asText(),
+                    isDefault = row.has("default_version"),
+                )
+            }
+
+    /**
+     * Matches a parenthetical name suffix (e.g. `"4"` from `Waterskin(4)`, `"3"` from
+     * `Antipoison(3)`) against [versions]' `version_anchor` text. Verified live the anchor shape
+     * isn't consistent across pages — Waterskin's is `"(4)"` (parens around the digit),
+     * Antipoison's is `"4 dose"` (leading word token, no parens) — so this strips surrounding
+     * parens from the anchor and accepts either a full match or a match on the anchor's first
+     * whitespace-separated token, case-insensitively. Returns null unless exactly one *distinct id*
+     * satisfies it — an ambiguous or absent match is never guessed at.
+     */
+    fun matchVersionBySuffix(versions: List<ItemVersion>, suffix: String): ItemVersion? {
+        val target = suffix.trim().lowercase()
+        val matches =
+            versions.filter { version ->
+                val anchor =
+                    version.versionAnchor?.trim()?.removeSurrounding("(", ")")?.trim()?.lowercase()
+                        ?: return@filter false
+                anchor == target || anchor.substringBefore(' ') == target
+            }
+        return if (matches.map { it.id }.distinct().size == 1) matches.first() else null
+    }
+
+    /**
+     * Picks the `default_version` row among [versions] (a suffixless name that hit a multi-version
+     * page, e.g. `Candle` -> `Unlit`/`Lit`, `Karambwan vessel` -> `Empty`/`Baited`) — but only when
+     * exactly one distinct id is marked default; ambiguity is left unresolved rather than guessed.
+     */
+    fun defaultVersion(versions: List<ItemVersion>): ItemVersion? {
+        val defaults = versions.filter { it.isDefault }
+        return if (defaults.map { it.id }.distinct().size == 1) defaults.first() else null
+    }
+}

--- a/tools/wiki-dumping/src/test/kotlin/org/rsmod/tools/wiki/dumping/wiki/bucket/BucketSourceTest.kt
+++ b/tools/wiki-dumping/src/test/kotlin/org/rsmod/tools/wiki/dumping/wiki/bucket/BucketSourceTest.kt
@@ -1,0 +1,107 @@
+package org.rsmod.tools.wiki.dumping.wiki.bucket
+
+import java.nio.file.Files
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+class BucketSourceTest {
+    private fun src(
+        vararg responses: String,
+        offline: Boolean = false,
+    ): Pair<BucketSource, MutableList<String>> {
+        val urls = mutableListOf<String>()
+        val iter = responses.iterator()
+        val source =
+            BucketSource(
+                cacheDir = Files.createTempDirectory("bucket-test"),
+                offline = offline,
+                throttleMillis = 0,
+                fetch = { url ->
+                    urls += url
+                    iter.next()
+                },
+            )
+        return source to urls
+    }
+
+    @Test
+    fun `builds escaped query and parses rows`() =
+        runBlocking<Unit> {
+            val (source, urls) = src("""{"bucket":[{"sold_item":"Bread"}]}""")
+            val rows =
+                source.rows(
+                    "storeline",
+                    listOf("sold_item"),
+                    "page_name" to "Bob's Axes",
+                    cacheKey = "bobs",
+                )
+            assertEquals(1, rows.size)
+            assertEquals("Bread", rows[0].requireText("sold_item", "test"))
+            val decoded = java.net.URLDecoder.decode(urls.single(), "UTF-8")
+            assertEquals(true, decoded.contains("where('page_name','Bob\\'s Axes')"))
+        }
+
+    @Test
+    fun `escapes backslashes before quotes in query values`() =
+        runBlocking<Unit> {
+            val (source, urls) = src("""{"bucket":[{"sold_item":"Bread"}]}""")
+            source.rows(
+                "storeline",
+                listOf("sold_item"),
+                "page_name" to "C:\\Bob's Axes",
+                cacheKey = "bobs-backslash",
+            )
+            val decoded = java.net.URLDecoder.decode(urls.single(), "UTF-8")
+            assertEquals(true, decoded.contains("where('page_name','C:\\\\Bob\\'s Axes')"))
+        }
+
+    @Test
+    fun `pages with offset until short page`() =
+        runBlocking<Unit> {
+            val full = (1..3).joinToString(",") { """{"n":"$it"}""" }
+            val (source, urls) = src("""{"bucket":[$full]}""", """{"bucket":[{"n":"4"}]}""")
+            val rows = source.rows("b", listOf("n"), null, cacheKey = "k", limit = 3)
+            assertEquals(4, rows.size)
+            assertEquals(2, urls.size)
+            assertEquals(true, java.net.URLDecoder.decode(urls[1], "UTF-8").contains(".offset(3)"))
+        }
+
+    @Test
+    fun `second call hits cache, offline replays cache, offline miss throws`() =
+        runBlocking<Unit> {
+            val dir = Files.createTempDirectory("bucket-test")
+            val one =
+                BucketSource(
+                    dir,
+                    offline = false,
+                    throttleMillis = 0,
+                    fetch = { """{"bucket":[{"a":"1"}]}""" },
+                )
+            one.rows("b", listOf("a"), null, cacheKey = "k")
+            val offline =
+                BucketSource(
+                    dir,
+                    offline = true,
+                    throttleMillis = 0,
+                    fetch = { error("no network in offline") },
+                )
+            assertEquals(1, offline.rows("b", listOf("a"), null, cacheKey = "k").size)
+            assertThrows(IllegalStateException::class.java) {
+                runBlocking { offline.rows("b", listOf("a"), null, cacheKey = "other") }
+            }
+        }
+
+    @Test
+    fun `api error and missing field throw`() =
+        runBlocking<Unit> {
+            val (errSource, _) = src("""{"error":"Bucket nope does not exist."}""")
+            assertThrows(IllegalStateException::class.java) {
+                runBlocking { errSource.rows("nope", listOf("a"), null, cacheKey = "k") }
+            }
+            val (okSource, _) = src("""{"bucket":[{"a":"1"}]}""")
+            val row = okSource.rows("b", listOf("a"), null, cacheKey = "k2").single()
+            assertThrows(IllegalStateException::class.java) { row.requireText("missing", "ctx") }
+        }
+}

--- a/tools/wiki-dumping/src/test/kotlin/org/rsmod/tools/wiki/dumping/wiki/bucket/ShopBucketsTest.kt
+++ b/tools/wiki-dumping/src/test/kotlin/org/rsmod/tools/wiki/dumping/wiki/bucket/ShopBucketsTest.kt
@@ -1,0 +1,213 @@
+package org.rsmod.tools.wiki.dumping.wiki.bucket
+
+import java.nio.file.Files
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class ShopBucketsTest {
+    private fun buckets(response: String): ShopBuckets =
+        ShopBuckets(
+            BucketSource(
+                Files.createTempDirectory("shop-buckets"),
+                throttleMillis = 0,
+                fetch = { response },
+            )
+        )
+
+    @Test
+    fun `storeTables groups by store_notes and adapts fields`() = runBlocking {
+        val b =
+            buckets(
+                """{"bucket":[
+              {"sold_item":"Bread","store_stock":"15","restock_time":"100","store_sell_multiplier":"1000","store_buy_multiplier":"800","store_delta":"20","store_currency":"Coins","store_notes":""},
+              {"sold_item":"Cake","store_stock":"5","restock_time":"800","store_sell_multiplier":"1000","store_buy_multiplier":"800","store_delta":"20","store_currency":"Coins","store_notes":""},
+              {"sold_item":"Toktz-xil-ul","store_stock":"500","restock_time":"10","store_sell_multiplier":"1500","store_buy_multiplier":"150","store_delta":"20","store_currency":"Tokkul","store_notes":"(Karamja gloves)"}
+            ]}"""
+            )
+        val tables = b.storeTables("Any Shop")
+        assertEquals(2, tables.size)
+        val default = tables[0]
+        assertNull(default.nameNotes)
+        assertEquals(listOf("Bread", "Cake"), default.lines.map { it.name })
+        assertEquals(15, default.lines[0].stock)
+        assertEquals(100, default.lines[0].restockCycles)
+        assertEquals(1000, default.sellMultiplier)
+        val gloves = tables[1]
+        assertEquals("Karamja gloves", gloves.nameNotes)
+        assertEquals(1500, gloves.sellMultiplier)
+    }
+
+    @Test
+    fun `selectTable resolves default and namenotes selectors`() = runBlocking {
+        // Real `store_notes` shapes verified live 2026-08-17 against Ali's Discount Wares
+        // (subkey-before-section, no comma) and Culinaromancer's Chest (section-prefixed with a
+        // comma, colliding with an unprefixed table using the same subkey text).
+        val b =
+            buckets(
+                """{"bucket":[
+              {"sold_item":"Pot","store_stock":"5","restock_time":"100","store_sell_multiplier":"1000","store_buy_multiplier":"550","store_delta":"2","store_currency":"Coins","store_notes":"(general)"},
+              {"sold_item":"Oak blackjack","store_stock":"5","restock_time":"100","store_sell_multiplier":"1000","store_buy_multiplier":"550","store_delta":"2","store_currency":"Coins","store_notes":"(Defensive blackjacks)"},
+              {"sold_item":"Bread","store_stock":"15","restock_time":"100","store_sell_multiplier":"1300","store_buy_multiplier":"400","store_delta":"20","store_currency":"Coins","store_notes":"(food, 2 Subquests)"},
+              {"sold_item":"Ring of wealth","store_stock":"1","restock_time":"100","store_sell_multiplier":"1300","store_buy_multiplier":"400","store_delta":"20","store_currency":"Coins","store_notes":"(2 Subquest)"}
+            ]}"""
+            )
+        val tables = b.storeTables("Any Shop")
+        assertEquals("Pot", b.selectTable(tables, "general")!!.lines.single().name)
+        assertEquals(
+            "Oak blackjack",
+            b.selectTable(tables, "blackjacks|Defensive")!!.lines.single().name,
+        )
+        // section+subkey must disambiguate the food-prefixed table from the unprefixed one that
+        // happens to share the same subkey text.
+        assertEquals("Bread", b.selectTable(tables, "food|2 Subquests")!!.lines.single().name)
+        assertEquals(
+            "Ring of wealth",
+            b.selectTable(tables, "items|2 Subquest")!!.lines.single().name,
+        )
+        assertNull(b.selectTable(tables, "no-such-table"))
+    }
+
+    @Test
+    fun `selectTable treats a blank or 'Default' selector as the unnamed table`() = runBlocking {
+        val b =
+            buckets(
+                """{"bucket":[
+              {"sold_item":"Scimitar","store_stock":"5","restock_time":"100","store_sell_multiplier":"1000","store_buy_multiplier":"500","store_delta":"20","store_currency":"Coins","store_notes":""},
+              {"sold_item":"Special scimitar","store_stock":"5","restock_time":"100","store_sell_multiplier":"1000","store_buy_multiplier":"500","store_delta":"20","store_currency":"Coins","store_notes":"(Monkey Madness I)"}
+            ]}"""
+            )
+        val tables = b.storeTables("Any Shop")
+        assertEquals("Scimitar", b.selectTable(tables, null)!!.lines.single().name)
+        assertEquals("Scimitar", b.selectTable(tables, "Default")!!.lines.single().name)
+    }
+
+    @Test
+    fun `listShops adapts infobox_shop rows`() = runBlocking {
+        val b =
+            buckets(
+                """{"bucket":[{"page_name":"Bob's Brilliant Axes.","shop_name":"Bob's Brilliant Axes"}]}"""
+            )
+        val shops = b.listShops()
+        assertEquals("Bob's Brilliant Axes.", shops.single().pageTitle)
+        assertEquals("Bob's Brilliant Axes", shops.single().infoboxName)
+        assertNull(shops.single().rsName)
+    }
+
+    @Test
+    fun `itemPageIds reads repeated id field`() = runBlocking {
+        val b = buckets("""{"bucket":[{"id":["2309"]}]}""")
+        assertEquals(listOf(2309), b.itemPageIds("Bread"))
+    }
+
+    @Test
+    fun `itemVersions parses default_version as key-presence and reads the repeated item_id`() =
+        runBlocking {
+            // Real infobox_item shape verified live 2026-08-17 against the Waterskin and Candle
+            // pages: `default_version` is present (empty string) on the default row, absent on the
+            // others — it is not a literal boolean.
+            val b =
+                buckets(
+                    """{"bucket":[
+                  {"item_id":["1825"],"version_anchor":"(3)","item_name":"Waterskin(3)"},
+                  {"item_id":["1823"],"default_version":"","version_anchor":"(4)","item_name":"Waterskin(4)"}
+                ]}"""
+                )
+            val versions = b.itemVersions("Waterskin")
+            assertEquals(2, versions.size)
+            assertEquals(1825, versions[0].id)
+            assertEquals("(3)", versions[0].versionAnchor)
+            assertEquals(false, versions[0].isDefault)
+            assertEquals(1823, versions[1].id)
+            assertEquals(true, versions[1].isDefault)
+        }
+
+    @Test
+    fun `itemVersionsByName filters non-numeric ids and finds names on other pages`() =
+        runBlocking {
+            // Real infobox_item shape verified live 2026-08-17: "Unlit torch" (page "Torch") and
+            // "Bronze spear(kp)" (page "Bronze spear") aren't derivable from the display name by
+            // stripping a suffix, but an exact item_name match finds them directly. "Candle" also
+            // matches a decoy non-game row whose item_id is the literal string "interface8128",
+            // which
+            // must be dropped rather than parsed as a real id.
+            val b =
+                buckets(
+                    """{"bucket":[
+              {"page_name":"Torch","default_version":"","item_name":"Unlit torch","item_id":["596"],"version_anchor":"Unlit"}
+            ]}"""
+                )
+            val versions = b.itemVersionsByName("Unlit torch")
+            assertEquals(1, versions.size)
+            assertEquals(596, versions.single().id)
+            assertEquals(true, versions.single().isDefault)
+
+            val candle =
+                buckets(
+                    """{"bucket":[
+              {"page_name":"Candle","default_version":"","item_name":"Candle","item_id":["36"],"version_anchor":"Unlit"},
+              {"item_name":"Candle","default_version":"","page_name":"Candles (interface item)","item_id":["interface8128"]}
+            ]}"""
+                )
+            val candleVersions = candle.itemVersionsByName("Candle")
+            assertEquals(1, candleVersions.size)
+            assertEquals(36, candleVersions.single().id)
+        }
+
+    @Test
+    fun `matchVersionBySuffix handles both live anchor shapes`() = runBlocking {
+        // Waterskin's anchor is "(N)" (parens around the digit); Antipoison's is "N dose" (a
+        // leading word token, no parens) — both verified live 2026-08-17. Bronze spear's "(kp)"
+        // maps to an unrelated anchor ("Karambwan poison") that must NOT fuzzy-match "kp".
+        val waterskin =
+            listOf(
+                ItemVersion("Waterskin(3)", 1825, "(3)", isDefault = false),
+                ItemVersion("Waterskin(4)", 1823, "(4)", isDefault = true),
+            )
+        val bucketsInstance = buckets("{}")
+        assertEquals(1825, bucketsInstance.matchVersionBySuffix(waterskin, "3")!!.id)
+        assertEquals(1823, bucketsInstance.matchVersionBySuffix(waterskin, "4")!!.id)
+        assertNull(bucketsInstance.matchVersionBySuffix(waterskin, "5"))
+
+        val antipoison =
+            listOf(
+                ItemVersion("Antipoison(3)", 175, "3 dose", isDefault = false),
+                ItemVersion("Antipoison(4)", 2446, "4 dose", isDefault = true),
+            )
+        assertEquals(175, bucketsInstance.matchVersionBySuffix(antipoison, "3")!!.id)
+
+        val spear =
+            listOf(
+                ItemVersion("Bronze spear(kp)", 3170, "Karambwan poison", isDefault = false),
+                ItemVersion("Bronze spear", 1237, "Unpoisoned", isDefault = true),
+            )
+        assertNull(bucketsInstance.matchVersionBySuffix(spear, "kp"))
+    }
+
+    @Test
+    fun `defaultVersion accepts exactly one default row, declines ambiguity`() = runBlocking {
+        val b = buckets("{}")
+        // Candle: Unlit (default) / Lit — verified live 2026-08-17.
+        val candle =
+            listOf(
+                ItemVersion("Candle", 36, "Unlit", isDefault = true),
+                ItemVersion("Lit candle", 33, "Lit", isDefault = false),
+            )
+        assertEquals(36, b.defaultVersion(candle)!!.id)
+
+        val noDefault =
+            listOf(
+                ItemVersion("A", 1, "X", isDefault = false),
+                ItemVersion("B", 2, "Y", isDefault = false),
+            )
+        assertNull(b.defaultVersion(noDefault))
+
+        val twoDefaults =
+            listOf(
+                ItemVersion("A", 1, "X", isDefault = true),
+                ItemVersion("B", 2, "Y", isDefault = true),
+            )
+        assertNull(b.defaultVersion(twoDefaults))
+    }
+}


### PR DESCRIPTION
This adds a `--source=auto|bucket|dump` flag to `mapShopNames`/`dumpShops`. `bucket` reads the wiki's structured Bucket API (`storeline`, `infobox_shop`, `infobox_item`, plus item id lookups) instead of parsing wikitext, with an on-disk response cache so repeat runs are offline-safe. `auto` prefers a local XML dump when one is present and falls back to `bucket`; dump mode itself is unchanged.

The dump path only works against a machine-local wiki XML dump, which has kept anyone else from running the shop tools for #116. Bucket mode needs nothing but network access, or the cache.

Regenerating all 279 checked-in shop TOMLs via `--source=bucket` reproduces 258 byte-identical. The other 21 are accounted for: 5 real wiki drift since the original dump, 5 where Bucket surfaces pricing/name metadata the old regex parser missed, 3 pre-existing defects in the checked-in files, and 8 pages Bucket structurally can't serve (mostly `bucket=No` template opt-outs) that now skip with a logged reason instead of writing wrong stock. An offline replay matched the networked run 272/272, the server boots clean, and 14 new tests cover the API client and shop readers.
