### PR TITLE
Dump stock TOML for the newly mapped shops

### DIFF
--- a/.data/raw-cache/server/shops/aldarin_food_store.toml
+++ b/.data/raw-cache/server/shops/aldarin_food_store.toml
@@ -1,0 +1,105 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.aldarin_food_store"
+name = "Faustus' Fruit and Veg"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 700
+delta = 10
+
+size = 17
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.cooking_apple"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.banana"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.orange"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.lemon"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.lime"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.pineapple"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.redberries"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.grapes"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.tomato"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.potato"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.onion"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.cabbage"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.papaya"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.coconut"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.strawberry"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.watermelon"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.sweetcorn"
+count = 0
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/aldarin_gem_store.toml
+++ b/.data/raw-cache/server/shops/aldarin_gem_store.toml
@@ -1,0 +1,60 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.aldarin_gem_store"
+name = "Toci's Gem Store"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 700
+delta = 30
+
+size = 8
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.uncut_sapphire"
+count = 3
+restockCycles = 12000
+
+[[inventory.stock]]
+obj = "obj.uncut_emerald"
+count = 2
+restockCycles = 24000
+
+[[inventory.stock]]
+obj = "obj.uncut_ruby"
+count = 1
+restockCycles = 36000
+
+[[inventory.stock]]
+obj = "obj.uncut_diamond"
+count = 0
+restockCycles = 12000
+
+[[inventory.stock]]
+obj = "obj.sapphire"
+count = 3
+restockCycles = 12000
+
+[[inventory.stock]]
+obj = "obj.emerald"
+count = 2
+restockCycles = 24000
+
+[[inventory.stock]]
+obj = "obj.ruby"
+count = 1
+restockCycles = 36000
+
+[[inventory.stock]]
+obj = "obj.diamond"
+count = 0
+restockCycles = 12000
+

--- a/.data/raw-cache/server/shops/aldarin_wine_store.toml
+++ b/.data/raw-cache/server/shops/aldarin_wine_store.toml
@@ -1,0 +1,60 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.aldarin_wine_store"
+name = "Moonrise Wines"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 700
+delta = 0
+
+size = 8
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.blackbird_red"
+count = 20
+restockCycles = -1
+
+[[inventory.stock]]
+obj = "obj.chilhuac_red"
+count = 20
+restockCycles = -1
+
+[[inventory.stock]]
+obj = "obj.eclipse_wine"
+count = 20
+restockCycles = -1
+
+[[inventory.stock]]
+obj = "obj.ixcoztic_white"
+count = 20
+restockCycles = -1
+
+[[inventory.stock]]
+obj = "obj.metztonalli_white"
+count = 20
+restockCycles = -1
+
+[[inventory.stock]]
+obj = "obj.tonameyo_white"
+count = 20
+restockCycles = -1
+
+[[inventory.stock]]
+obj = "obj.chichilihui_rose"
+count = 20
+restockCycles = -1
+
+[[inventory.stock]]
+obj = "obj.imperial_rose"
+count = 20
+restockCycles = -1
+

--- a/.data/raw-cache/server/shops/auburn_general_store.toml
+++ b/.data/raw-cache/server/shops/auburn_general_store.toml
@@ -1,0 +1,95 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.auburn_general_store"
+name = "Auburnvale General Store"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1300
+buyMultiplier = 400
+delta = 30
+
+size = 15
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.chisel"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.spade"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.hammer"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.knife"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.bronze_axe"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.tinderbox"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.pestle_and_mortar"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.torch_unlit"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.needle"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.thread"
+count = 30
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.rope"
+count = 10
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.pot_empty"
+count = 15
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.bucket_empty"
+count = 15
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.bowl_empty"
+count = 15
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.vial_empty"
+count = 15
+restockCycles = 150
+

--- a/.data/raw-cache/server/shops/bakery3.toml
+++ b/.data/raw-cache/server/shops/bakery3.toml
@@ -1,0 +1,40 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.bakery3"
+name = "Kourend Castle Baker's Stall."
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 800
+delta = 20
+
+size = 4
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.bread"
+count = 30
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.cake"
+count = 10
+restockCycles = 1000
+
+[[inventory.stock]]
+obj = "obj.chocolate_slice"
+count = 5
+restockCycles = 400
+
+[[inventory.stock]]
+obj = "obj.chocolate_bar"
+count = 15
+restockCycles = 250
+

--- a/.data/raw-cache/server/shops/cam_torum_shop_baker.toml
+++ b/.data/raw-cache/server/shops/cam_torum_shop_baker.toml
@@ -1,0 +1,55 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.cam_torum_shop_baker"
+name = "Yarnio's Baked Goods"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 550
+delta = 10
+
+size = 7
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.bread"
+count = 15
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.cake"
+count = 5
+restockCycles = 800
+
+[[inventory.stock]]
+obj = "obj.redberry_pie"
+count = 5
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.meat_pie"
+count = 5
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.apple_pie"
+count = 5
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.garden_pie"
+count = 5
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.fish_pie"
+count = 5
+restockCycles = 150
+

--- a/.data/raw-cache/server/shops/cam_torum_shop_blacksmith.toml
+++ b/.data/raw-cache/server/shops/cam_torum_shop_blacksmith.toml
@@ -1,0 +1,120 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.cam_torum_shop_blacksmith"
+name = "Cam Torum Blacksmith"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 600
+delta = 20
+
+size = 20
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.bronze_dagger"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.iron_dagger"
+count = 4
+restockCycles = 200
+
+[[inventory.stock]]
+obj = "obj.steel_dagger"
+count = 4
+restockCycles = 400
+
+[[inventory.stock]]
+obj = "obj.mithril_dagger"
+count = 3
+restockCycles = 3000
+
+[[inventory.stock]]
+obj = "obj.adamant_dagger"
+count = 2
+restockCycles = 12000
+
+[[inventory.stock]]
+obj = "obj.bronze_sword"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.iron_sword"
+count = 4
+restockCycles = 200
+
+[[inventory.stock]]
+obj = "obj.steel_sword"
+count = 4
+restockCycles = 400
+
+[[inventory.stock]]
+obj = "obj.mithril_sword"
+count = 3
+restockCycles = 3000
+
+[[inventory.stock]]
+obj = "obj.adamant_sword"
+count = 2
+restockCycles = 12000
+
+[[inventory.stock]]
+obj = "obj.bronze_warhammer"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.iron_warhammer"
+count = 4
+restockCycles = 200
+
+[[inventory.stock]]
+obj = "obj.steel_warhammer"
+count = 4
+restockCycles = 400
+
+[[inventory.stock]]
+obj = "obj.mithril_warhammer"
+count = 3
+restockCycles = 3000
+
+[[inventory.stock]]
+obj = "obj.adamnt_warhammer"
+count = 2
+restockCycles = 12000
+
+[[inventory.stock]]
+obj = "obj.bronze_sq_shield"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.iron_sq_shield"
+count = 4
+restockCycles = 200
+
+[[inventory.stock]]
+obj = "obj.steel_sq_shield"
+count = 4
+restockCycles = 400
+
+[[inventory.stock]]
+obj = "obj.mithril_sq_shield"
+count = 3
+restockCycles = 3000
+
+[[inventory.stock]]
+obj = "obj.adamant_sq_shield"
+count = 2
+restockCycles = 12000
+

--- a/.data/raw-cache/server/shops/cam_torum_shop_general.toml
+++ b/.data/raw-cache/server/shops/cam_torum_shop_general.toml
@@ -1,0 +1,110 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.cam_torum_shop_general"
+name = "Cam Torum General Store"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1300
+buyMultiplier = 400
+delta = 30
+
+size = 18
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.chisel"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.spade"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.hammer"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.knife"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.bronze_pickaxe"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.tinderbox"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.pestle_and_mortar"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.needle"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.thread"
+count = 30
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.torch_unlit"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.rope"
+count = 10
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.charcoal"
+count = 10
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.jug_empty"
+count = 15
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.bucket_empty"
+count = 15
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.bowl_empty"
+count = 15
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.piedish"
+count = 15
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.pack_jug_empty"
+count = 5
+restockCycles = 30
+
+[[inventory.stock]]
+obj = "obj.pack_bucket"
+count = 5
+restockCycles = 30
+

--- a/.data/raw-cache/server/shops/cam_torum_shop_herbalist.toml
+++ b/.data/raw-cache/server/shops/cam_torum_shop_herbalist.toml
@@ -1,0 +1,55 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.cam_torum_shop_herbalist"
+name = "Huito's Herbal Supplies"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 700
+delta = 30
+
+size = 7
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.pestle_and_mortar"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.vial_empty"
+count = 100
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.vial_water"
+count = 100
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.eye_of_newt"
+count = 50
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.pack_vial_empty"
+count = 100
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.pack_vial_water"
+count = 100
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.pack_eye_newt"
+count = 50
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/cam_torum_shop_jewellery.toml
+++ b/.data/raw-cache/server/shops/cam_torum_shop_jewellery.toml
@@ -1,0 +1,140 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.cam_torum_shop_jewellery"
+name = "Conara's Jewels"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 700
+delta = 20
+
+size = 24
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.sapphire"
+count = 3
+restockCycles = -1
+
+[[inventory.stock]]
+obj = "obj.emerald"
+count = 2
+restockCycles = -1
+
+[[inventory.stock]]
+obj = "obj.ruby"
+count = 2
+restockCycles = -1
+
+[[inventory.stock]]
+obj = "obj.diamond"
+count = 0
+restockCycles = 4000
+
+[[inventory.stock]]
+obj = "obj.gold_ring"
+count = 3
+restockCycles = 1000
+
+[[inventory.stock]]
+obj = "obj.gold_necklace"
+count = 3
+restockCycles = 1000
+
+[[inventory.stock]]
+obj = "obj.strung_gold_amulet"
+count = 3
+restockCycles = 1000
+
+[[inventory.stock]]
+obj = "obj.jewl_gold_bracelet"
+count = 3
+restockCycles = 1000
+
+[[inventory.stock]]
+obj = "obj.sapphire_ring"
+count = 0
+restockCycles = 1000
+
+[[inventory.stock]]
+obj = "obj.emerald_ring"
+count = 0
+restockCycles = 2000
+
+[[inventory.stock]]
+obj = "obj.ruby_ring"
+count = 0
+restockCycles = 2000
+
+[[inventory.stock]]
+obj = "obj.diamond_ring"
+count = 0
+restockCycles = 6000
+
+[[inventory.stock]]
+obj = "obj.sapphire_necklace"
+count = 0
+restockCycles = 2000
+
+[[inventory.stock]]
+obj = "obj.emerald_necklace"
+count = 0
+restockCycles = 2000
+
+[[inventory.stock]]
+obj = "obj.ruby_necklace"
+count = 0
+restockCycles = 3000
+
+[[inventory.stock]]
+obj = "obj.diamond_necklace"
+count = 0
+restockCycles = 6000
+
+[[inventory.stock]]
+obj = "obj.strung_sapphire_amulet"
+count = 0
+restockCycles = 2000
+
+[[inventory.stock]]
+obj = "obj.strung_emerald_amulet"
+count = 0
+restockCycles = 3000
+
+[[inventory.stock]]
+obj = "obj.strung_ruby_amulet"
+count = 0
+restockCycles = 4000
+
+[[inventory.stock]]
+obj = "obj.strung_diamond_amulet"
+count = 0
+restockCycles = 5000
+
+[[inventory.stock]]
+obj = "obj.jewl_sapphire_bracelet"
+count = 0
+restockCycles = 2000
+
+[[inventory.stock]]
+obj = "obj.jewl_emerald_bracelet"
+count = 0
+restockCycles = 3000
+
+[[inventory.stock]]
+obj = "obj.jewl_ruby_bracelet"
+count = 0
+restockCycles = 4000
+
+[[inventory.stock]]
+obj = "obj.jewl_diamond_bracelet"
+count = 0
+restockCycles = 5000
+

--- a/.data/raw-cache/server/shops/cam_torum_shop_magic.toml
+++ b/.data/raw-cache/server/shops/cam_torum_shop_magic.toml
@@ -1,0 +1,100 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.cam_torum_shop_magic"
+name = "The Runic Emporium"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 550
+delta = 1
+
+size = 16
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.airrune"
+count = 5000
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.waterrune"
+count = 5000
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.earthrune"
+count = 5000
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.firerune"
+count = 5000
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.mindrune"
+count = 3000
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.bodyrune"
+count = 3000
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.chaosrune"
+count = 1000
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.naturerune"
+count = 500
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.lawrune"
+count = 500
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.deathrune"
+count = 500
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.pack_airrune"
+count = 100
+restockCycles = 16
+
+[[inventory.stock]]
+obj = "obj.pack_waterrune"
+count = 100
+restockCycles = 16
+
+[[inventory.stock]]
+obj = "obj.pack_earthrune"
+count = 100
+restockCycles = 16
+
+[[inventory.stock]]
+obj = "obj.pack_firerune"
+count = 100
+restockCycles = 16
+
+[[inventory.stock]]
+obj = "obj.pack_mindrune"
+count = 50
+restockCycles = 16
+
+[[inventory.stock]]
+obj = "obj.pack_chaosrune"
+count = 30
+restockCycles = 16
+

--- a/.data/raw-cache/server/shops/cam_torum_shop_mining.toml
+++ b/.data/raw-cache/server/shops/cam_torum_shop_mining.toml
@@ -1,0 +1,60 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.cam_torum_shop_mining"
+name = "Tizoro's Pickaxes"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 600
+delta = 20
+
+size = 8
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.hammer"
+count = 6
+restockCycles = 22
+
+[[inventory.stock]]
+obj = "obj.chisel"
+count = 6
+restockCycles = 22
+
+[[inventory.stock]]
+obj = "obj.bronze_pickaxe"
+count = 6
+restockCycles = 22
+
+[[inventory.stock]]
+obj = "obj.iron_pickaxe"
+count = 5
+restockCycles = 22
+
+[[inventory.stock]]
+obj = "obj.steel_pickaxe"
+count = 4
+restockCycles = 22
+
+[[inventory.stock]]
+obj = "obj.mithril_pickaxe"
+count = 3
+restockCycles = 170
+
+[[inventory.stock]]
+obj = "obj.adamant_pickaxe"
+count = 2
+restockCycles = 470
+
+[[inventory.stock]]
+obj = "obj.rune_pickaxe"
+count = 1
+restockCycles = 675
+

--- a/.data/raw-cache/server/shops/deepfin_dwarf_durrik_shop.toml
+++ b/.data/raw-cache/server/shops/deepfin_dwarf_durrik_shop.toml
@@ -1,0 +1,120 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.deepfin_dwarf_durrik_shop"
+name = "Durrik's Goods"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 2500
+buyMultiplier = 150
+delta = 20
+
+size = 20
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.spade"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.chisel"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.hammer"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.tinderbox"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.rope"
+count = 10
+restockCycles = 30
+
+[[inventory.stock]]
+obj = "obj.steel_pickaxe"
+count = 4
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.rune_warhammer"
+count = 1
+restockCycles = -1
+
+[[inventory.stock]]
+obj = "obj.lovakengj_dynamite_fused"
+count = 20
+restockCycles = 1000
+
+[[inventory.stock]]
+obj = "obj.hunting_antelopemoon_fur"
+count = 0
+restockCycles = 800
+
+[[inventory.stock]]
+obj = "obj.bucket_sand"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.seaweed"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.flax"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.silk"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.spicespot"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.cosmicrune"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.deathrune"
+count = 200
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.brandy"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.blue_dragon_scale"
+count = 5
+restockCycles = 200
+
+[[inventory.stock]]
+obj = "obj.orangedye"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.gold_bar"
+count = 10
+restockCycles = 200
+

--- a/.data/raw-cache/server/shops/deepfin_point_oreshop.toml
+++ b/.data/raw-cache/server/shops/deepfin_point_oreshop.toml
@@ -1,0 +1,75 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.deepfin_point_oreshop"
+name = "Deepfin Point Ore Exchange"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1100
+buyMultiplier = 700
+delta = 20
+
+size = 11
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.copper_ore"
+count = 40
+restockCycles = 50
+
+[[inventory.stock]]
+obj = "obj.tin_ore"
+count = 40
+restockCycles = 50
+
+[[inventory.stock]]
+obj = "obj.iron_ore"
+count = 20
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.silver_ore"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.lead_ore"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.gold_ore"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.mithril_ore"
+count = 5
+restockCycles = 200
+
+[[inventory.stock]]
+obj = "obj.adamantite_ore"
+count = 0
+restockCycles = 500
+
+[[inventory.stock]]
+obj = "obj.nickel_ore"
+count = 0
+restockCycles = 800
+
+[[inventory.stock]]
+obj = "obj.runite_ore"
+count = 0
+restockCycles = 2000
+
+[[inventory.stock]]
+obj = "obj.coal"
+count = 20
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/fortis_shop_baker.toml
+++ b/.data/raw-cache/server/shops/fortis_shop_baker.toml
@@ -1,0 +1,35 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.fortis_shop_baker"
+name = "Fortis Baker's Stall"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 800
+delta = 20
+
+size = 3
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.bread"
+count = 15
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.cake"
+count = 5
+restockCycles = 800
+
+[[inventory.stock]]
+obj = "obj.chocolate_slice"
+count = 5
+restockCycles = 200
+

--- a/.data/raw-cache/server/shops/fortis_shop_blacksmith.toml
+++ b/.data/raw-cache/server/shops/fortis_shop_blacksmith.toml
@@ -1,0 +1,170 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.fortis_shop_blacksmith"
+name = "Fortis Blacksmith"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 600
+delta = 20
+
+size = 30
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.bronze_platebody"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.iron_platebody"
+count = 4
+restockCycles = 200
+
+[[inventory.stock]]
+obj = "obj.steel_platebody"
+count = 4
+restockCycles = 400
+
+[[inventory.stock]]
+obj = "obj.mithril_platebody"
+count = 3
+restockCycles = 3000
+
+[[inventory.stock]]
+obj = "obj.adamant_platebody"
+count = 2
+restockCycles = 12000
+
+[[inventory.stock]]
+obj = "obj.bronze_platelegs"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.iron_platelegs"
+count = 4
+restockCycles = 200
+
+[[inventory.stock]]
+obj = "obj.steel_platelegs"
+count = 4
+restockCycles = 400
+
+[[inventory.stock]]
+obj = "obj.mithril_platelegs"
+count = 3
+restockCycles = 3000
+
+[[inventory.stock]]
+obj = "obj.adamant_platelegs"
+count = 2
+restockCycles = 12000
+
+[[inventory.stock]]
+obj = "obj.bronze_plateskirt"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.iron_plateskirt"
+count = 4
+restockCycles = 200
+
+[[inventory.stock]]
+obj = "obj.steel_plateskirt"
+count = 4
+restockCycles = 400
+
+[[inventory.stock]]
+obj = "obj.mithril_plateskirt"
+count = 3
+restockCycles = 3000
+
+[[inventory.stock]]
+obj = "obj.adamant_plateskirt"
+count = 2
+restockCycles = 12000
+
+[[inventory.stock]]
+obj = "obj.bronze_longsword"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.iron_longsword"
+count = 4
+restockCycles = 200
+
+[[inventory.stock]]
+obj = "obj.steel_longsword"
+count = 4
+restockCycles = 400
+
+[[inventory.stock]]
+obj = "obj.mithril_longsword"
+count = 3
+restockCycles = 3000
+
+[[inventory.stock]]
+obj = "obj.adamant_longsword"
+count = 2
+restockCycles = 12000
+
+[[inventory.stock]]
+obj = "obj.bronze_scimitar"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.iron_scimitar"
+count = 4
+restockCycles = 200
+
+[[inventory.stock]]
+obj = "obj.steel_scimitar"
+count = 4
+restockCycles = 400
+
+[[inventory.stock]]
+obj = "obj.mithril_scimitar"
+count = 3
+restockCycles = 3000
+
+[[inventory.stock]]
+obj = "obj.adamant_scimitar"
+count = 2
+restockCycles = 12000
+
+[[inventory.stock]]
+obj = "obj.bronze_spear"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.iron_spear"
+count = 4
+restockCycles = 200
+
+[[inventory.stock]]
+obj = "obj.steel_spear"
+count = 4
+restockCycles = 400
+
+[[inventory.stock]]
+obj = "obj.mithril_spear"
+count = 3
+restockCycles = 3000
+
+[[inventory.stock]]
+obj = "obj.adamant_spear"
+count = 2
+restockCycles = 12000
+

--- a/.data/raw-cache/server/shops/fortis_shop_crafting.toml
+++ b/.data/raw-cache/server/shops/fortis_shop_crafting.toml
@@ -1,0 +1,80 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.fortis_shop_crafting"
+name = "Artima's Crafting Supplies"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 650
+delta = 20
+
+size = 12
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.chisel"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.hammer"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.needle"
+count = 5
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.thread"
+count = 50
+restockCycles = 5
+
+[[inventory.stock]]
+obj = "obj.shears"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.glassblowingpipe"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.ring_mould"
+count = 4
+restockCycles = 50
+
+[[inventory.stock]]
+obj = "obj.necklace_mould"
+count = 4
+restockCycles = 50
+
+[[inventory.stock]]
+obj = "obj.amulet_mould"
+count = 4
+restockCycles = 50
+
+[[inventory.stock]]
+obj = "obj.jewl_bracelet_mould"
+count = 4
+restockCycles = 50
+
+[[inventory.stock]]
+obj = "obj.tiara_mould"
+count = 4
+restockCycles = 50
+
+[[inventory.stock]]
+obj = "obj.xbows_silver_bolt_mould"
+count = 4
+restockCycles = 50
+

--- a/.data/raw-cache/server/shops/fortis_shop_farming.toml
+++ b/.data/raw-cache/server/shops/fortis_shop_farming.toml
@@ -1,0 +1,140 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.fortis_shop_farming"
+name = "Agelus' Farm Shop"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 700
+delta = 10
+
+size = 24
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.rake"
+count = 10
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.dibber"
+count = 10
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.secateurs"
+count = 10
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.spade"
+count = 10
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.gardening_trowel"
+count = 10
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.watering_can_0"
+count = 10
+restockCycles = 5
+
+[[inventory.stock]]
+obj = "obj.plantpot_compost"
+count = 30
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.pack_plant_pot_compost"
+count = 30
+restockCycles = 5
+
+[[inventory.stock]]
+obj = "obj.bucket_compost"
+count = 30
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.pack_compost"
+count = 30
+restockCycles = 50
+
+[[inventory.stock]]
+obj = "obj.sack_empty"
+count = 30
+restockCycles = 2
+
+[[inventory.stock]]
+obj = "obj.pack_sack"
+count = 30
+restockCycles = 2
+
+[[inventory.stock]]
+obj = "obj.basket_empty"
+count = 30
+restockCycles = 2
+
+[[inventory.stock]]
+obj = "obj.pack_basket"
+count = 30
+restockCycles = 2
+
+[[inventory.stock]]
+obj = "obj.bucket_empty"
+count = 30
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.pack_bucket"
+count = 30
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.plant_cure"
+count = 50
+restockCycles = 5
+
+[[inventory.stock]]
+obj = "obj.grain"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.potato"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.onion"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.cabbage"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.tomato"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.sweetcorn"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.barley"
+count = 0
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/fortis_shop_food.toml
+++ b/.data/raw-cache/server/shops/fortis_shop_food.toml
@@ -1,0 +1,140 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.fortis_shop_food"
+name = "Cobado's Groceries"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 700
+delta = 10
+
+size = 24
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.cooking_apple"
+count = 20
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.pineapple"
+count = 15
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.banana"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.tomato"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.potato"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.onion"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.cabbage"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.orange"
+count = 2
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.papaya"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.coconut"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.strawberry"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.watermelon"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.sweetcorn"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.redberries"
+count = 2
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.cheese"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.chocolate_bar"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.raw_chicken"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.raw_beef"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.raw_rabbit"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.raw_herring"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.raw_cod"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.raw_tuna"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.raw_bass"
+count = 3
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.raw_swordfish"
+count = 2
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/fortis_shop_fur.toml
+++ b/.data/raw-cache/server/shops/fortis_shop_fur.toml
@@ -1,0 +1,100 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.fortis_shop_fur"
+name = "Fortis Fur Stall"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1200
+buyMultiplier = 950
+delta = 20
+
+size = 16
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.fur"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.grey_wolf_fur"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.varlamore_jaguar_fur"
+count = 2
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.hunting_fennecfox_fur"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.hunting_antelopemoon_fur"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.hunting_antelopesun_fur"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.huntingbeast_polar_fur"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.huntingbeast_woodland_fur"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.huntingbeast_jungle_fur"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.huntingbeast_desert_fur"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.hunting_fur_jaguar_shabby"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.hunting_fur_jaguar_perfect"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.hunting_fur_leopard_shabby"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.hunting_fur_leopard_perfect"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.hunting_fur_tiger_shabby"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.hunting_fur_tiger_perfect"
+count = 0
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/fortis_shop_gems.toml
+++ b/.data/raw-cache/server/shops/fortis_shop_gems.toml
@@ -1,0 +1,40 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.fortis_shop_gems"
+name = "Fortis Gem Stall"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1500
+buyMultiplier = 800
+delta = 30
+
+size = 4
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.sapphire"
+count = 2
+restockCycles = 15000
+
+[[inventory.stock]]
+obj = "obj.emerald"
+count = 1
+restockCycles = 35000
+
+[[inventory.stock]]
+obj = "obj.ruby"
+count = 1
+restockCycles = 60000
+
+[[inventory.stock]]
+obj = "obj.diamond"
+count = 0
+restockCycles = 4000
+

--- a/.data/raw-cache/server/shops/fortis_shop_maces.toml
+++ b/.data/raw-cache/server/shops/fortis_shop_maces.toml
@@ -1,0 +1,50 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.fortis_shop_maces"
+name = "Spike's Spikes"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1300
+buyMultiplier = 400
+delta = 30
+
+size = 6
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.bronze_mace"
+count = 5
+restockCycles = -1
+
+[[inventory.stock]]
+obj = "obj.iron_mace"
+count = 4
+restockCycles = -1
+
+[[inventory.stock]]
+obj = "obj.steel_mace"
+count = 4
+restockCycles = -1
+
+[[inventory.stock]]
+obj = "obj.mithril_mace"
+count = 3
+restockCycles = -1
+
+[[inventory.stock]]
+obj = "obj.adamant_mace"
+count = 2
+restockCycles = -1
+
+[[inventory.stock]]
+obj = "obj.rune_mace"
+count = 1
+restockCycles = -1
+

--- a/.data/raw-cache/server/shops/fortis_shop_seamstress.toml
+++ b/.data/raw-cache/server/shops/fortis_shop_seamstress.toml
@@ -1,0 +1,75 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.fortis_shop_seamstress"
+name = "Floria's Fashion"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 550
+delta = 10
+
+size = 11
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.leather_gloves"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.leather_boots"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.black_skirt"
+count = 3
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.blue_skirt"
+count = 2
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.pink_skirt"
+count = 2
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.green_cape"
+count = 4
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.blue_cape"
+count = 4
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.yellow_cape"
+count = 4
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.red_cape"
+count = 4
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.white_apron"
+count = 3
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.brown_apron"
+count = 3
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/fortis_shop_silk.toml
+++ b/.data/raw-cache/server/shops/fortis_shop_silk.toml
@@ -1,0 +1,35 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.fortis_shop_silk"
+name = "Fortis Silk Stall"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 500
+buyMultiplier = 500
+delta = 0
+
+size = 3
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.needle"
+count = 5
+restockCycles = 5
+
+[[inventory.stock]]
+obj = "obj.thread"
+count = 100
+restockCycles = 5
+
+[[inventory.stock]]
+obj = "obj.silk"
+count = 50
+restockCycles = 25
+

--- a/.data/raw-cache/server/shops/fortis_shop_spices.toml
+++ b/.data/raw-cache/server/shops/fortis_shop_spices.toml
@@ -1,0 +1,35 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.fortis_shop_spices"
+name = "Fortis Spice Stall"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 700
+delta = 20
+
+size = 3
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.knife"
+count = 5
+restockCycles = 5
+
+[[inventory.stock]]
+obj = "obj.spicespot"
+count = 20
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.garlic"
+count = 10
+restockCycles = 10
+

--- a/.data/raw-cache/server/shops/fossil_general_store.toml
+++ b/.data/raw-cache/server/shops/fossil_general_store.toml
@@ -1,0 +1,70 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.fossil_general_store"
+name = "Fossil Island General Store"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1300
+buyMultiplier = 400
+delta = 30
+
+size = 10
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.pot_empty"
+count = 5
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.jug_empty"
+count = 2
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.bucket_empty"
+count = 3
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.pack_bucket"
+count = 15
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.bowl_empty"
+count = 2
+restockCycles = 50
+
+[[inventory.stock]]
+obj = "obj.cake_tin"
+count = 2
+restockCycles = 50
+
+[[inventory.stock]]
+obj = "obj.tinderbox"
+count = 2
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.chisel"
+count = 2
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.hammer"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.rope"
+count = 5
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/fur_shop_guild.toml
+++ b/.data/raw-cache/server/shops/fur_shop_guild.toml
@@ -1,0 +1,120 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.fur_shop_guild"
+name = "Pellem's Fur Store"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1300
+buyMultiplier = 400
+delta = 20
+
+size = 20
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.thread"
+count = 100
+restockCycles = 5
+
+[[inventory.stock]]
+obj = "obj.needle"
+count = 3
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.werewolve_fur"
+count = 3
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.fur"
+count = 3
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.grey_wolf_fur"
+count = 3
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.varlamore_jaguar_fur"
+count = 2
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.hunting_fennecfox_fur"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.hunting_antelopemoon_fur"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.hunting_antelopesun_fur"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.huntingbeast_polar_fur"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.huntingbeast_woodland_fur"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.huntingbeast_jungle_fur"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.huntingbeast_desert_fur"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.hunting_fur_jaguar_shabby"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.hunting_fur_jaguar_perfect"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.hunting_fur_leopard_shabby"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.hunting_fur_leopard_perfect"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.hunting_fur_tiger_shabby"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.hunting_fur_tiger_perfect"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.hg_mixedhide_base"
+count = 10
+restockCycles = 14
+

--- a/.data/raw-cache/server/shops/gnomeshop.toml
+++ b/.data/raw-cache/server/shops/gnomeshop.toml
@@ -1,0 +1,80 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.gnomeshop"
+name = "Bolkoy's Village Shop"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1300
+buyMultiplier = 400
+delta = 30
+
+size = 12
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.pot_empty"
+count = 3
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.bronze_pickaxe"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.jug_empty"
+count = 2
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.pack_jug_empty"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.shears"
+count = 2
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.bucket_empty"
+count = 2
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.pack_bucket"
+count = 15
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.tinderbox"
+count = 2
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.chisel"
+count = 2
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.hammer"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.bronze_arrow"
+count = 30
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.cooked_meat"
+count = 2
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/great_conch_crafting_shop.toml
+++ b/.data/raw-cache/server/shops/great_conch_crafting_shop.toml
@@ -1,0 +1,85 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.great_conch_crafting_shop"
+name = "Elder Coco's Crafting Stall"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 650
+delta = 20
+
+size = 13
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.chisel"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.hammer"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.needle"
+count = 5
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.thread"
+count = 50
+restockCycles = 5
+
+[[inventory.stock]]
+obj = "obj.glassblowingpipe"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.ring_mould"
+count = 4
+restockCycles = 50
+
+[[inventory.stock]]
+obj = "obj.necklace_mould"
+count = 4
+restockCycles = 50
+
+[[inventory.stock]]
+obj = "obj.amulet_mould"
+count = 4
+restockCycles = 50
+
+[[inventory.stock]]
+obj = "obj.jewl_bracelet_mould"
+count = 4
+restockCycles = 50
+
+[[inventory.stock]]
+obj = "obj.sapphire"
+count = 2
+restockCycles = -1
+
+[[inventory.stock]]
+obj = "obj.emerald"
+count = 1
+restockCycles = -1
+
+[[inventory.stock]]
+obj = "obj.ruby"
+count = 1
+restockCycles = -1
+
+[[inventory.stock]]
+obj = "obj.diamond"
+count = 0
+restockCycles = -1
+

--- a/.data/raw-cache/server/shops/great_conch_farming_shop.toml
+++ b/.data/raw-cache/server/shops/great_conch_farming_shop.toml
@@ -1,0 +1,105 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.great_conch_farming_shop"
+name = "Elder Reggle's Farming Shop"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 700
+delta = 10
+
+size = 17
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.rake"
+count = 10
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.dibber"
+count = 10
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.secateurs"
+count = 10
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.spade"
+count = 10
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.gardening_trowel"
+count = 10
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.watering_can_0"
+count = 10
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.plantpot_compost"
+count = 30
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.pack_plant_pot_compost"
+count = 30
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.bucket_compost"
+count = 30
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.pack_compost"
+count = 30
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.sack_empty"
+count = 30
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.pack_sack"
+count = 30
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.basket_empty"
+count = 30
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.pack_basket"
+count = 30
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.bucket_empty"
+count = 30
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.pack_bucket"
+count = 30
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.plant_cure"
+count = 50
+restockCycles = 20
+

--- a/.data/raw-cache/server/shops/great_conch_fishing_shop.toml
+++ b/.data/raw-cache/server/shops/great_conch_fishing_shop.toml
@@ -1,0 +1,115 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.great_conch_fishing_shop"
+name = "Elder Krill's Fishing Stall"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 700
+delta = 20
+
+size = 19
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.net"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.big_net"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.fishing_rod"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.fly_fishing_rod"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.harpoon"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.lobster_pot"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.fishing_bait"
+count = 1000
+restockCycles = 1
+
+[[inventory.stock]]
+obj = "obj.pack_fishing_bait"
+count = 100
+restockCycles = 5
+
+[[inventory.stock]]
+obj = "obj.feather"
+count = 1000
+restockCycles = 1
+
+[[inventory.stock]]
+obj = "obj.pack_feather"
+count = 100
+restockCycles = 5
+
+[[inventory.stock]]
+obj = "obj.raw_mackerel"
+count = 10
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_cod"
+count = 10
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_pike"
+count = 10
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_trout"
+count = 10
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_salmon"
+count = 10
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_tuna"
+count = 10
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_lobster"
+count = 4
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_bass"
+count = 6
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_swordfish"
+count = 4
+restockCycles = 150
+

--- a/.data/raw-cache/server/shops/great_conch_herblore_shop.toml
+++ b/.data/raw-cache/server/shops/great_conch_herblore_shop.toml
@@ -1,0 +1,60 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.great_conch_herblore_shop"
+name = "Elder Raley's Herblore Stall"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 700
+delta = 10
+
+size = 8
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.pestle_and_mortar"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.knife"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.vial_empty"
+count = 100
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.vial_water"
+count = 100
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.eye_of_newt"
+count = 50
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.pack_vial_empty"
+count = 100
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.pack_vial_water"
+count = 100
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.pack_eye_newt"
+count = 50
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/great_conch_hunter_shop.toml
+++ b/.data/raw-cache/server/shops/great_conch_hunter_shop.toml
@@ -1,0 +1,80 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.great_conch_hunter_shop"
+name = "Elder Strom's Hunting Stall"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1200
+buyMultiplier = 700
+delta = 20
+
+size = 12
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.hunting_butterfly_net"
+count = 5
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.butterfly_jar"
+count = 100
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.magic_imp_box"
+count = 30
+restockCycles = 50
+
+[[inventory.stock]]
+obj = "obj.noose_wand"
+count = 50
+restockCycles = 5
+
+[[inventory.stock]]
+obj = "obj.hunting_ojibway_bird_snare"
+count = 50
+restockCycles = 5
+
+[[inventory.stock]]
+obj = "obj.hunting_box_trap"
+count = 25
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.hunting_teasing_stick"
+count = 5
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.torch_unlit"
+count = 20
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.hunting_snare"
+count = 10
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.pack_ojibway_bird_snare"
+count = 3
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.pack_box_trap"
+count = 3
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.pack_magic_imp_box"
+count = 3
+restockCycles = 10
+

--- a/.data/raw-cache/server/shops/great_conch_weapon_shop.toml
+++ b/.data/raw-cache/server/shops/great_conch_weapon_shop.toml
@@ -1,0 +1,75 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.great_conch_weapon_shop"
+name = "Elder Blunn's Spear and Shield Stall"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 600
+delta = 20
+
+size = 11
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.bronze_spear"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.iron_spear"
+count = 8
+restockCycles = 200
+
+[[inventory.stock]]
+obj = "obj.steel_spear"
+count = 8
+restockCycles = -1
+
+[[inventory.stock]]
+obj = "obj.mithril_spear"
+count = 6
+restockCycles = -1
+
+[[inventory.stock]]
+obj = "obj.adamant_spear"
+count = 4
+restockCycles = -1
+
+[[inventory.stock]]
+obj = "obj.bronze_kiteshield"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.iron_kiteshield"
+count = 4
+restockCycles = 200
+
+[[inventory.stock]]
+obj = "obj.steel_kiteshield"
+count = 4
+restockCycles = -1
+
+[[inventory.stock]]
+obj = "obj.mithril_kiteshield"
+count = 3
+restockCycles = -1
+
+[[inventory.stock]]
+obj = "obj.adamant_kiteshield"
+count = 2
+restockCycles = -1
+
+[[inventory.stock]]
+obj = "obj.tortugan_shield"
+count = 10
+restockCycles = 50
+

--- a/.data/raw-cache/server/shops/hallowed_rewardshop.toml
+++ b/.data/raw-cache/server/shops/hallowed_rewardshop.toml
@@ -1,0 +1,70 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.hallowed_rewardshop"
+name = "Mysterious Hallowed Goods"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 1000
+delta = 0
+
+size = 10
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.hallowed_teleport"
+count = 1000
+restockCycles = 1
+
+[[inventory.stock]]
+obj = "obj.hallowed_token"
+count = 100
+restockCycles = 1
+
+[[inventory.stock]]
+obj = "obj.hallowed_grapple"
+count = 100
+restockCycles = 1
+
+[[inventory.stock]]
+obj = "obj.hallowed_focus"
+count = 100
+restockCycles = 1
+
+[[inventory.stock]]
+obj = "obj.hallowed_symbol"
+count = 100
+restockCycles = 1
+
+[[inventory.stock]]
+obj = "obj.hallowed_hammer"
+count = 100
+restockCycles = 1
+
+[[inventory.stock]]
+obj = "obj.hallowed_ring"
+count = 100
+restockCycles = 1
+
+[[inventory.stock]]
+obj = "obj.dark_dye"
+count = 100
+restockCycles = 1
+
+[[inventory.stock]]
+obj = "obj.dark_acorn"
+count = 100
+restockCycles = 1
+
+[[inventory.stock]]
+obj = "obj.hallowed_sack"
+count = 100
+restockCycles = 1
+

--- a/.data/raw-cache/server/shops/hunting_shop_guild.toml
+++ b/.data/raw-cache/server/shops/hunting_shop_guild.toml
@@ -1,0 +1,80 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.hunting_shop_guild"
+name = "Imia's Supplies"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1300
+buyMultiplier = 400
+delta = 20
+
+size = 12
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.hunting_butterfly_net"
+count = 5
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.butterfly_jar"
+count = 100
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.magic_imp_box"
+count = 30
+restockCycles = 50
+
+[[inventory.stock]]
+obj = "obj.noose_wand"
+count = 50
+restockCycles = 5
+
+[[inventory.stock]]
+obj = "obj.hunting_ojibway_bird_snare"
+count = 50
+restockCycles = 5
+
+[[inventory.stock]]
+obj = "obj.hunting_box_trap"
+count = 25
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.hunting_teasing_stick"
+count = 5
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.torch_unlit"
+count = 20
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.hunting_snare"
+count = 10
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.pack_ojibway_bird_snare"
+count = 3
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.pack_box_trap"
+count = 3
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.pack_magic_imp_box"
+count = 3
+restockCycles = 10
+

--- a/.data/raw-cache/server/shops/kastorifarmingstore.toml
+++ b/.data/raw-cache/server/shops/kastorifarmingstore.toml
@@ -1,0 +1,105 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.kastorifarmingstore"
+name = "Kastori Farming Supplies"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 700
+delta = 10
+
+size = 17
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.rake"
+count = 5
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.dibber"
+count = 5
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.secateurs"
+count = 5
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.spade"
+count = 5
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.gardening_trowel"
+count = 10
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.watering_can_0"
+count = 30
+restockCycles = 5
+
+[[inventory.stock]]
+obj = "obj.plantpot_compost"
+count = 100
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.pack_plant_pot_compost"
+count = 30
+restockCycles = 5
+
+[[inventory.stock]]
+obj = "obj.bucket_compost"
+count = 30
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.pack_compost"
+count = 30
+restockCycles = 50
+
+[[inventory.stock]]
+obj = "obj.sack_empty"
+count = 30
+restockCycles = 2
+
+[[inventory.stock]]
+obj = "obj.pack_sack"
+count = 30
+restockCycles = 2
+
+[[inventory.stock]]
+obj = "obj.basket_empty"
+count = 30
+restockCycles = 2
+
+[[inventory.stock]]
+obj = "obj.pack_basket"
+count = 30
+restockCycles = 2
+
+[[inventory.stock]]
+obj = "obj.bucket_empty"
+count = 30
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.pack_bucket"
+count = 30
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.plant_cure"
+count = 50
+restockCycles = 5
+

--- a/.data/raw-cache/server/shops/kastorifishingstore.toml
+++ b/.data/raw-cache/server/shops/kastorifishingstore.toml
@@ -1,0 +1,110 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.kastorifishingstore"
+name = "Sulisal's Superb Fishing Store"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 700
+delta = 10
+
+size = 18
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.net"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.big_net"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.fishing_rod"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.fly_fishing_rod"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.harpoon"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.lobster_pot"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.fishing_bait"
+count = 1000
+restockCycles = 1
+
+[[inventory.stock]]
+obj = "obj.pack_fishing_bait"
+count = 100
+restockCycles = 5
+
+[[inventory.stock]]
+obj = "obj.feather"
+count = 1000
+restockCycles = 1
+
+[[inventory.stock]]
+obj = "obj.pack_feather"
+count = 100
+restockCycles = 5
+
+[[inventory.stock]]
+obj = "obj.raw_sardine"
+count = 10
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_herring"
+count = 10
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_mackerel"
+count = 10
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_cod"
+count = 10
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_tuna"
+count = 10
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_bass"
+count = 6
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_swordfish"
+count = 4
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_lobster"
+count = 4
+restockCycles = 150
+

--- a/.data/raw-cache/server/shops/kebos_farming_equipment_shop.toml
+++ b/.data/raw-cache/server/shops/kebos_farming_equipment_shop.toml
@@ -1,0 +1,110 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.kebos_farming_equipment_shop"
+name = "Allanna's Farming Shop"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 600
+delta = 20
+
+size = 18
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.rake"
+count = 5
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.dibber"
+count = 5
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.secateurs"
+count = 5
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.spade"
+count = 5
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.gardening_trowel"
+count = 3
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.watering_can_0"
+count = 30
+restockCycles = 5
+
+[[inventory.stock]]
+obj = "obj.plantpot_empty"
+count = 100
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.plantpot_compost"
+count = 100
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.pack_plant_pot_compost"
+count = 10
+restockCycles = 5
+
+[[inventory.stock]]
+obj = "obj.bucket_compost"
+count = 100
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.pack_compost"
+count = 10
+restockCycles = 50
+
+[[inventory.stock]]
+obj = "obj.bucket_empty"
+count = 100
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.pack_bucket"
+count = 15
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.sack_empty"
+count = 100
+restockCycles = 2
+
+[[inventory.stock]]
+obj = "obj.pack_sack"
+count = 30
+restockCycles = 2
+
+[[inventory.stock]]
+obj = "obj.basket_empty"
+count = 100
+restockCycles = 2
+
+[[inventory.stock]]
+obj = "obj.pack_basket"
+count = 30
+restockCycles = 2
+
+[[inventory.stock]]
+obj = "obj.plant_cure"
+count = 40
+restockCycles = 5
+

--- a/.data/raw-cache/server/shops/kebos_farming_seed_shop.toml
+++ b/.data/raw-cache/server/shops/kebos_farming_seed_shop.toml
@@ -1,0 +1,100 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.kebos_farming_seed_shop"
+name = "Amelia's Seed Shop"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 600
+delta = 20
+
+size = 16
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.potato_seed"
+count = 20
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.onion_seed"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.cabbage_seed"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.tomato_seed"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.sweetcorn_seed"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.strawberry_seed"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.watermelon_seed"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.barley_seed"
+count = 20
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.jute_seed"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.rosemary_seed"
+count = 20
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.marigold_seed"
+count = 20
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.hammerstone_hop_seed"
+count = 20
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.asgarnian_hop_seed"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.yanillian_hop_seed"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.krandorian_hop_seed"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.wildblood_hop_seed"
+count = 0
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/kebos_weapon_shop.toml
+++ b/.data/raw-cache/server/shops/kebos_weapon_shop.toml
@@ -1,0 +1,70 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.kebos_weapon_shop"
+name = "Mount Karuulm Weapon Shop"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 600
+delta = 20
+
+size = 10
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.steel_spear"
+count = 2
+restockCycles = 200
+
+[[inventory.stock]]
+obj = "obj.mithril_spear"
+count = 1
+restockCycles = 3000
+
+[[inventory.stock]]
+obj = "obj.adamant_spear"
+count = 1
+restockCycles = 5000
+
+[[inventory.stock]]
+obj = "obj.rune_spear"
+count = 1
+restockCycles = 8000
+
+[[inventory.stock]]
+obj = "obj.steel_battleaxe"
+count = 2
+restockCycles = 200
+
+[[inventory.stock]]
+obj = "obj.mithril_battleaxe"
+count = 1
+restockCycles = 3000
+
+[[inventory.stock]]
+obj = "obj.adamant_battleaxe"
+count = 1
+restockCycles = 5000
+
+[[inventory.stock]]
+obj = "obj.steel_warhammer"
+count = 2
+restockCycles = 200
+
+[[inventory.stock]]
+obj = "obj.mithril_warhammer"
+count = 1
+restockCycles = 3000
+
+[[inventory.stock]]
+obj = "obj.adamnt_warhammer"
+count = 1
+restockCycles = 5000
+

--- a/.data/raw-cache/server/shops/khazardshop.toml
+++ b/.data/raw-cache/server/shops/khazardshop.toml
@@ -1,0 +1,100 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.khazardshop"
+name = "Khazard General Store"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1400
+buyMultiplier = 400
+delta = 10
+
+size = 16
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.bronze_pickaxe"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.pot_empty"
+count = 3
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.jug_empty"
+count = 2
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.pack_jug_empty"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.shears"
+count = 2
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.bucket_empty"
+count = 2
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.pack_bucket"
+count = 15
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.tinderbox"
+count = 2
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.chisel"
+count = 2
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.hammer"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.rope"
+count = 30
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.pot_flour"
+count = 30
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.bucket_bailing"
+count = 30
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.swamppaste"
+count = 5000
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.knife"
+count = 2
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.bronze_axe"
+count = 5
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/lovakengj_dynamite_shop.toml
+++ b/.data/raw-cache/server/shops/lovakengj_dynamite_shop.toml
@@ -1,0 +1,30 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.lovakengj_dynamite_shop"
+name = "Thirus Urkar's Fine Dynamite Store"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 11500
+buyMultiplier = 500
+delta = 1
+
+size = 2
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.lovakengj_dynamite_fused"
+count = 2000
+restockCycles = 2500
+
+[[inventory.stock]]
+obj = "obj.tinderbox"
+count = 2
+restockCycles = 3
+

--- a/.data/raw-cache/server/shops/lunami_axe_store.toml
+++ b/.data/raw-cache/server/shops/lunami_axe_store.toml
@@ -1,0 +1,70 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.lunami_axe_store"
+name = "Lunami's Axe Shop"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 550
+delta = 10
+
+size = 10
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.bronze_axe"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.iron_axe"
+count = 5
+restockCycles = 200
+
+[[inventory.stock]]
+obj = "obj.steel_axe"
+count = 3
+restockCycles = 400
+
+[[inventory.stock]]
+obj = "obj.mithril_axe"
+count = 2
+restockCycles = 200
+
+[[inventory.stock]]
+obj = "obj.adamant_axe"
+count = 1
+restockCycles = 1100
+
+[[inventory.stock]]
+obj = "obj.bronze_battleaxe"
+count = 4
+restockCycles = 200
+
+[[inventory.stock]]
+obj = "obj.iron_battleaxe"
+count = 3
+restockCycles = 300
+
+[[inventory.stock]]
+obj = "obj.steel_battleaxe"
+count = 2
+restockCycles = 500
+
+[[inventory.stock]]
+obj = "obj.mithril_battleaxe"
+count = 1
+restockCycles = 1000
+
+[[inventory.stock]]
+obj = "obj.adamant_battleaxe"
+count = 1
+restockCycles = 15000
+

--- a/.data/raw-cache/server/shops/mag_emelio_shop.toml
+++ b/.data/raw-cache/server/shops/mag_emelio_shop.toml
@@ -1,0 +1,25 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.mag_emelio_shop"
+name = "Emelio's Kebab Shop"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 500
+delta = 0
+
+size = 1
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.varlamorian_kebab"
+count = 20
+restockCycles = 20
+

--- a/.data/raw-cache/server/shops/mguild_oreshop.toml
+++ b/.data/raw-cache/server/shops/mguild_oreshop.toml
@@ -1,0 +1,55 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.mguild_oreshop"
+name = "Hendor's Awesome Ores"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 700
+delta = 20
+
+size = 7
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.copper_ore"
+count = 0
+restockCycles = 15000
+
+[[inventory.stock]]
+obj = "obj.tin_ore"
+count = 0
+restockCycles = 15000
+
+[[inventory.stock]]
+obj = "obj.iron_ore"
+count = 0
+restockCycles = 5000
+
+[[inventory.stock]]
+obj = "obj.mithril_ore"
+count = 0
+restockCycles = 2000
+
+[[inventory.stock]]
+obj = "obj.adamantite_ore"
+count = 0
+restockCycles = 800
+
+[[inventory.stock]]
+obj = "obj.runite_ore"
+count = 0
+restockCycles = 200
+
+[[inventory.stock]]
+obj = "obj.coal"
+count = 0
+restockCycles = 5000
+

--- a/.data/raw-cache/server/shops/mistrock_mining_store.toml
+++ b/.data/raw-cache/server/shops/mistrock_mining_store.toml
@@ -1,0 +1,90 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.mistrock_mining_store"
+name = "Mistrock Mining Supplies"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 700
+delta = 20
+
+size = 14
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.hammer"
+count = 6
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.chisel"
+count = 6
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.bronze_pickaxe"
+count = 6
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.iron_pickaxe"
+count = 6
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.steel_pickaxe"
+count = 6
+restockCycles = 200
+
+[[inventory.stock]]
+obj = "obj.copper_ore"
+count = 0
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.tin_ore"
+count = 0
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.iron_ore"
+count = 0
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.mithril_ore"
+count = 0
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.adamantite_ore"
+count = 0
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.runite_ore"
+count = 0
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.coal"
+count = 0
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.silver_ore"
+count = 0
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.gold_ore"
+count = 0
+restockCycles = 10
+

--- a/.data/raw-cache/server/shops/mistrock_shield_store.toml
+++ b/.data/raw-cache/server/shops/mistrock_shield_store.toml
@@ -1,0 +1,70 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.mistrock_shield_store"
+name = "Shields of Mistrock"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 600
+delta = 20
+
+size = 10
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.bronze_sq_shield"
+count = 6
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.bronze_kiteshield"
+count = 5
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.iron_sq_shield"
+count = 5
+restockCycles = 400
+
+[[inventory.stock]]
+obj = "obj.iron_kiteshield"
+count = 4
+restockCycles = 600
+
+[[inventory.stock]]
+obj = "obj.steel_sq_shield"
+count = 4
+restockCycles = 800
+
+[[inventory.stock]]
+obj = "obj.steel_kiteshield"
+count = 3
+restockCycles = 1500
+
+[[inventory.stock]]
+obj = "obj.mithril_sq_shield"
+count = 3
+restockCycles = 2000
+
+[[inventory.stock]]
+obj = "obj.mithril_kiteshield"
+count = 2
+restockCycles = 3000
+
+[[inventory.stock]]
+obj = "obj.adamant_sq_shield"
+count = 2
+restockCycles = 4000
+
+[[inventory.stock]]
+obj = "obj.adamant_kiteshield"
+count = 1
+restockCycles = 6000
+

--- a/.data/raw-cache/server/shops/mm2_javelin_store.toml
+++ b/.data/raw-cache/server/shops/mm2_javelin_store.toml
@@ -1,0 +1,50 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.mm2_javelin_store"
+name = "Oobapohk's Javelin Store"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 600
+delta = 1
+
+size = 6
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.bronze_javelin"
+count = 500
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.iron_javelin"
+count = 500
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.steel_javelin"
+count = 500
+restockCycles = 40
+
+[[inventory.stock]]
+obj = "obj.mithril_javelin"
+count = 500
+restockCycles = 60
+
+[[inventory.stock]]
+obj = "obj.adamant_javelin"
+count = 500
+restockCycles = 80
+
+[[inventory.stock]]
+obj = "obj.rune_javelin"
+count = 500
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/myths_guild_capes.toml
+++ b/.data/raw-cache/server/shops/myths_guild_capes.toml
@@ -1,0 +1,25 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.myths_guild_capes"
+name = "Mythical Cape Store"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 1000
+delta = 0
+
+size = 1
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.mythical_cape"
+count = 50
+restockCycles = 500
+

--- a/.data/raw-cache/server/shops/pandemonium_fishmonger.toml
+++ b/.data/raw-cache/server/shops/pandemonium_fishmonger.toml
@@ -1,0 +1,105 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.pandemonium_fishmonger"
+name = "Henderson's Catch of the Day"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 700
+delta = 10
+
+size = 17
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.net"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.big_net"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.fishing_rod"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.fly_fishing_rod"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.harpoon"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.lobster_pot"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.fishing_bait"
+count = 2000
+restockCycles = 1
+
+[[inventory.stock]]
+obj = "obj.pack_fishing_bait"
+count = 100
+restockCycles = 5
+
+[[inventory.stock]]
+obj = "obj.feather"
+count = 1000
+restockCycles = 1
+
+[[inventory.stock]]
+obj = "obj.pack_feather"
+count = 100
+restockCycles = 5
+
+[[inventory.stock]]
+obj = "obj.raw_shrimp"
+count = 10
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_sardine"
+count = 10
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_herring"
+count = 10
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_anchovies"
+count = 10
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_mackerel"
+count = 6
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_cod"
+count = 6
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_bass"
+count = 4
+restockCycles = 150
+

--- a/.data/raw-cache/server/shops/piscarilius_fishing_supplies.toml
+++ b/.data/raw-cache/server/shops/piscarilius_fishing_supplies.toml
@@ -1,0 +1,70 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.piscarilius_fishing_supplies"
+name = "Tynan's Fishing Supplies"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 850
+delta = 10
+
+size = 10
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.bucket_empty"
+count = 1000
+restockCycles = 1
+
+[[inventory.stock]]
+obj = "obj.net"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.big_net"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.fishing_rod"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.harpoon"
+count = 2
+restockCycles = 400
+
+[[inventory.stock]]
+obj = "obj.lobster_pot"
+count = 2
+restockCycles = 400
+
+[[inventory.stock]]
+obj = "obj.fishing_bait"
+count = 1200
+restockCycles = 1
+
+[[inventory.stock]]
+obj = "obj.piscarilius_sandworms"
+count = 500
+restockCycles = 50
+
+[[inventory.stock]]
+obj = "obj.pack_fishing_bait"
+count = 80
+restockCycles = 5
+
+[[inventory.stock]]
+obj = "obj.piscarilius_pack_sandworms"
+count = 50
+restockCycles = 5
+

--- a/.data/raw-cache/server/shops/piscarilius_generalstore.toml
+++ b/.data/raw-cache/server/shops/piscarilius_generalstore.toml
@@ -1,0 +1,70 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.piscarilius_generalstore"
+name = "Leenz's General Supplies"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1100
+buyMultiplier = 400
+delta = 10
+
+size = 10
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.pot_empty"
+count = 50000
+restockCycles = 1
+
+[[inventory.stock]]
+obj = "obj.jug_empty"
+count = 5
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.pack_jug_empty"
+count = 6
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.bucket_empty"
+count = 5
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.pack_bucket"
+count = 15
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.bowl_empty"
+count = 5
+restockCycles = 80
+
+[[inventory.stock]]
+obj = "obj.tinderbox"
+count = 2
+restockCycles = 3
+
+[[inventory.stock]]
+obj = "obj.hammer"
+count = 5
+restockCycles = 3
+
+[[inventory.stock]]
+obj = "obj.nails_bronze"
+count = 500
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.nails_iron"
+count = 500
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/port_roberts_cannonball_trader.toml
+++ b/.data/raw-cache/server/shops/port_roberts_cannonball_trader.toml
@@ -1,0 +1,50 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.port_roberts_cannonball_trader"
+name = "Port Roberts Cannonball Stall"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 2500
+buyMultiplier = 500
+delta = 0
+
+size = 6
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.bronze_cannonball"
+count = 10000
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.iron_cannonball"
+count = 10000
+restockCycles = 15
+
+[[inventory.stock]]
+obj = "obj.mcannonball"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.mithril_cannonball"
+count = 8000
+restockCycles = 15
+
+[[inventory.stock]]
+obj = "obj.adamant_cannonball"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.rune_cannonball"
+count = 0
+restockCycles = 200
+

--- a/.data/raw-cache/server/shops/port_roberts_fish_trader.toml
+++ b/.data/raw-cache/server/shops/port_roberts_fish_trader.toml
@@ -1,0 +1,90 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.port_roberts_fish_trader"
+name = "Port Roberts Fish Stall"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 700
+delta = 10
+
+size = 14
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.raw_shrimp"
+count = 10
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_sardine"
+count = 10
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_herring"
+count = 10
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_anchovies"
+count = 10
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_mackerel"
+count = 10
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_trout"
+count = 10
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_cod"
+count = 10
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_pike"
+count = 10
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_salmon"
+count = 10
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_tuna"
+count = 10
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_lobster"
+count = 6
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_bass"
+count = 6
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_swordfish"
+count = 4
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_shark"
+count = 0
+restockCycles = 150
+

--- a/.data/raw-cache/server/shops/port_roberts_fur_trader.toml
+++ b/.data/raw-cache/server/shops/port_roberts_fur_trader.toml
@@ -1,0 +1,90 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.port_roberts_fur_trader"
+name = "Port Roberts Fur Stall"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1200
+buyMultiplier = 950
+delta = 20
+
+size = 14
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.fur"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.grey_wolf_fur"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.varlamore_jaguar_fur"
+count = 2
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.hunting_fennecfox_fur"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.huntingbeast_polar_fur"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.huntingbeast_woodland_fur"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.huntingbeast_jungle_fur"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.huntingbeast_desert_fur"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.hunting_fur_jaguar_shabby"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.hunting_fur_jaguar_perfect"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.hunting_fur_leopard_shabby"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.hunting_fur_leopard_perfect"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.hunting_fur_tiger_shabby"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.hunting_fur_tiger_perfect"
+count = 0
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/port_roberts_gem_trader.toml
+++ b/.data/raw-cache/server/shops/port_roberts_gem_trader.toml
@@ -1,0 +1,40 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.port_roberts_gem_trader"
+name = "Port Roberts Gem Stall"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 700
+delta = 30
+
+size = 4
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.sapphire"
+count = 2
+restockCycles = 15000
+
+[[inventory.stock]]
+obj = "obj.emerald"
+count = 1
+restockCycles = 35000
+
+[[inventory.stock]]
+obj = "obj.ruby"
+count = 1
+restockCycles = 2000
+
+[[inventory.stock]]
+obj = "obj.diamond"
+count = 0
+restockCycles = 4000
+

--- a/.data/raw-cache/server/shops/port_roberts_ore_trader.toml
+++ b/.data/raw-cache/server/shops/port_roberts_ore_trader.toml
@@ -1,0 +1,75 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.port_roberts_ore_trader"
+name = "Port Roberts Ore Stall"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1100
+buyMultiplier = 700
+delta = 20
+
+size = 11
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.copper_ore"
+count = 20
+restockCycles = 50
+
+[[inventory.stock]]
+obj = "obj.tin_ore"
+count = 20
+restockCycles = 50
+
+[[inventory.stock]]
+obj = "obj.iron_ore"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.silver_ore"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.lead_ore"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.gold_ore"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.mithril_ore"
+count = 0
+restockCycles = 200
+
+[[inventory.stock]]
+obj = "obj.adamantite_ore"
+count = 0
+restockCycles = 500
+
+[[inventory.stock]]
+obj = "obj.nickel_ore"
+count = 0
+restockCycles = 800
+
+[[inventory.stock]]
+obj = "obj.runite_ore"
+count = 0
+restockCycles = 2000
+
+[[inventory.stock]]
+obj = "obj.coal"
+count = 10
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/port_roberts_silk_trader.toml
+++ b/.data/raw-cache/server/shops/port_roberts_silk_trader.toml
@@ -1,0 +1,35 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.port_roberts_silk_trader"
+name = "Port Roberts Silk Stall"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 500
+buyMultiplier = 500
+delta = 0
+
+size = 3
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.needle"
+count = 5
+restockCycles = 5
+
+[[inventory.stock]]
+obj = "obj.thread"
+count = 100
+restockCycles = 5
+
+[[inventory.stock]]
+obj = "obj.silk"
+count = 50
+restockCycles = 25
+

--- a/.data/raw-cache/server/shops/port_roberts_silver_trader.toml
+++ b/.data/raw-cache/server/shops/port_roberts_silver_trader.toml
@@ -1,0 +1,35 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.port_roberts_silver_trader"
+name = "Port Roberts Silver Stall"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 700
+delta = 20
+
+size = 3
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.silver_ore"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.silver_bar"
+count = 5
+restockCycles = 1000
+
+[[inventory.stock]]
+obj = "obj.nostringstar"
+count = 5
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/port_roberts_spice_trader.toml
+++ b/.data/raw-cache/server/shops/port_roberts_spice_trader.toml
@@ -1,0 +1,35 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.port_roberts_spice_trader"
+name = "Port Roberts Spice Stall"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 600
+delta = 20
+
+size = 3
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.knife"
+count = 5
+restockCycles = 2
+
+[[inventory.stock]]
+obj = "obj.spicespot"
+count = 20
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.garlic"
+count = 10
+restockCycles = 5
+

--- a/.data/raw-cache/server/shops/port_roberts_veg_trader.toml
+++ b/.data/raw-cache/server/shops/port_roberts_veg_trader.toml
@@ -1,0 +1,70 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.port_roberts_veg_trader"
+name = "Port Roberts Veg Stall"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 950
+delta = 20
+
+size = 10
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.potato"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.onion"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.cabbage"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.tomato"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.sweetcorn"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.potato_seed"
+count = 20
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.onion_seed"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.cabbage_seed"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.tomato_seed"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.sweetcorn_seed"
+count = 0
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/prif_food_store.toml
+++ b/.data/raw-cache/server/shops/prif_food_store.toml
@@ -1,0 +1,110 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.prif_food_store"
+name = "Prifddinas Foodstuffs"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 700
+delta = 10
+
+size = 18
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.pot_flour"
+count = 3
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.bucket_milk"
+count = 3
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.cod"
+count = 3
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.trout"
+count = 3
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.bass"
+count = 3
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.stew"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.bread"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.cheese"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.potato"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.onion"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.tomato"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.cabbage"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.banana"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.redberries"
+count = 3
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.raw_beef"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.raw_chicken"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.chocolate_bar"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.cake"
+count = 5
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/prif_mace_store.toml
+++ b/.data/raw-cache/server/shops/prif_mace_store.toml
@@ -1,0 +1,35 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.prif_mace_store"
+name = "Iwan's Maces"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 600
+delta = 10
+
+size = 3
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.mithril_mace"
+count = 3
+restockCycles = 3000
+
+[[inventory.stock]]
+obj = "obj.adamant_mace"
+count = 2
+restockCycles = 5000
+
+[[inventory.stock]]
+obj = "obj.rune_mace"
+count = 1
+restockCycles = 8000
+

--- a/.data/raw-cache/server/shops/prif_weapon_store.toml
+++ b/.data/raw-cache/server/shops/prif_weapon_store.toml
@@ -1,0 +1,60 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.prif_weapon_store"
+name = "Iorwerth's Arms"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1500
+buyMultiplier = 250
+delta = 10
+
+size = 8
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.adamant_dagger"
+count = 4
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.rune_dagger"
+count = 3
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.dragon_dagger"
+count = 2
+restockCycles = 500
+
+[[inventory.stock]]
+obj = "obj.adamant_scimitar"
+count = 2
+restockCycles = 500
+
+[[inventory.stock]]
+obj = "obj.rune_scimitar"
+count = 1
+restockCycles = 1000
+
+[[inventory.stock]]
+obj = "obj.adamant_halberd"
+count = 7
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.rune_halberd"
+count = 7
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.dragon_halberd"
+count = 5
+restockCycles = 500
+

--- a/.data/raw-cache/server/shops/pub_aldarin.toml
+++ b/.data/raw-cache/server/shops/pub_aldarin.toml
@@ -1,0 +1,105 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.pub_aldarin"
+name = "Sunlight's Sanctum"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 1000
+delta = 0
+
+size = 17
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.beer"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.cider"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.sunbeam_ale"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.greenmans_ale"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.vodka"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.rum"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.whisky"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.gin"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.brandy"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.moonlite"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.jug_wine"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.metztonalli_white"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.blackbird_red"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.eclipse_wine"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.cup_of_tea"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.stew"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.meat_pie"
+count = 0
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/pub_auburnvale.toml
+++ b/.data/raw-cache/server/shops/pub_auburnvale.toml
@@ -1,0 +1,80 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.pub_auburnvale"
+name = "Auburn Pub"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 1000
+delta = 0
+
+size = 12
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.beer"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.cider"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.sunbeam_ale"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.axemans_folly"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.vodka"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.rum"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.whisky"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.gin"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.moonlite"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.jug_wine"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.stew"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.meat_pie"
+count = 0
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/pub_cam_torum.toml
+++ b/.data/raw-cache/server/shops/pub_cam_torum.toml
@@ -1,0 +1,70 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.pub_cam_torum"
+name = "The Lost Pickaxe"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 1000
+delta = 0
+
+size = 10
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.beer"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.cider"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.dwarven_stout"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.wizards_mind_bomb"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.steamforge_brew"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.whisky"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.sunshine"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.jug_wine"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.stew"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.meat_pie"
+count = 0
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/pub_deepfin.toml
+++ b/.data/raw-cache/server/shops/pub_deepfin.toml
@@ -1,0 +1,65 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.pub_deepfin"
+name = "Deepfin Inn"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 0
+delta = 0
+
+size = 9
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.beer"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.cider"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.dwarven_stout"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.vodka"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.whisky"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.jug_wine"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.stew"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.meat_pie"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.kebab"
+count = 0
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/pub_fortis_1.toml
+++ b/.data/raw-cache/server/shops/pub_fortis_1.toml
@@ -1,0 +1,95 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.pub_fortis_1"
+name = "The Flaming Arrow"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 1000
+delta = 0
+
+size = 15
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.beer"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.cider"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.sunbeam_ale"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.vodka"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.rum"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.whisky"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.gin"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.moonlite"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.jug_wine"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.metztonalli_white"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.blackbird_red"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.eclipse_wine"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.cup_of_tea"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.stew"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.meat_pie"
+count = 0
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/pub_fortis_2.toml
+++ b/.data/raw-cache/server/shops/pub_fortis_2.toml
@@ -1,0 +1,75 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.pub_fortis_2"
+name = "Atlazora's Rest"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 1000
+delta = 0
+
+size = 11
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.beer"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.cider"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.sunbeam_ale"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.vodka"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.rum"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.whisky"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.gin"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.moonlite"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.jug_wine"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.stew"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.meat_pie"
+count = 0
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/pub_mistrock.toml
+++ b/.data/raw-cache/server/shops/pub_mistrock.toml
@@ -1,0 +1,70 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.pub_mistrock"
+name = "Stick Your Ore Inn"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 1000
+delta = 0
+
+size = 10
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.beer"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.cider"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.dwarven_stout"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.wizards_mind_bomb"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.steamforge_brew"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.whisky"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.sunshine"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.jug_wine"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.stew"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.meat_pie"
+count = 0
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/pub_nemus.toml
+++ b/.data/raw-cache/server/shops/pub_nemus.toml
@@ -1,0 +1,70 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.pub_nemus"
+name = "Nemus Retreat"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 1000
+delta = 0
+
+size = 10
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.beer"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.cider"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.sunbeam_ale"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.axemans_folly"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.greenmans_ale"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.vodka"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.rum"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.whisky"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.gin"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.stew"
+count = 0
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/pub_port_roberts.toml
+++ b/.data/raw-cache/server/shops/pub_port_roberts.toml
@@ -1,0 +1,65 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.pub_port_roberts"
+name = "The Rolling Tide"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 1000
+delta = 0
+
+size = 9
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.beer"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.cider"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.grog"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.vodka"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.rum"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.whisky"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.gin"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.stew"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.meat_pie"
+count = 0
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/pub_quetzacalli.toml
+++ b/.data/raw-cache/server/shops/pub_quetzacalli.toml
@@ -1,0 +1,75 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.pub_quetzacalli"
+name = "The Windbreaker"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 1000
+delta = 0
+
+size = 11
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.beer"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.cider"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.sunbeam_ale"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.vodka"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.rum"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.whisky"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.gin"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.moonlite"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.jug_wine"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.stew"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.meat_pie"
+count = 0
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/pub_tal_teklan.toml
+++ b/.data/raw-cache/server/shops/pub_tal_teklan.toml
@@ -1,0 +1,95 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.pub_tal_teklan"
+name = "The King's Inn"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 1000
+delta = 0
+
+size = 15
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.beer"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.cider"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.sunbeam_ale"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.vodka"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.rum"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.whisky"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.gin"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.moonlite"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.jug_wine"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.metztonalli_white"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.blackbird_red"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.eclipse_wine"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.cup_of_tea"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.stew"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.meat_pie"
+count = 0
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/quetzacalli_general_store.toml
+++ b/.data/raw-cache/server/shops/quetzacalli_general_store.toml
@@ -1,0 +1,95 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.quetzacalli_general_store"
+name = "Quetzacalli Gorge General Store"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1300
+buyMultiplier = 400
+delta = 30
+
+size = 15
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.bronze_pickaxe"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.bronze_axe"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.chisel"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.spade"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.hammer"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.knife"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.shears"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.tinderbox"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.pestle_and_mortar"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.torch_unlit"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.rope"
+count = 10
+restockCycles = 30
+
+[[inventory.stock]]
+obj = "obj.charcoal"
+count = 10
+restockCycles = 30
+
+[[inventory.stock]]
+obj = "obj.papyrus"
+count = 10
+restockCycles = 30
+
+[[inventory.stock]]
+obj = "obj.pot_empty"
+count = 15
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.bucket_empty"
+count = 15
+restockCycles = 20
+

--- a/.data/raw-cache/server/shops/salvager_overlook_platebody_store.toml
+++ b/.data/raw-cache/server/shops/salvager_overlook_platebody_store.toml
@@ -1,0 +1,45 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.salvager_overlook_platebody_store"
+name = "Salius' Armour Shop"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 600
+delta = 20
+
+size = 5
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.bronze_platebody"
+count = 6
+restockCycles = 80
+
+[[inventory.stock]]
+obj = "obj.iron_platebody"
+count = 5
+restockCycles = 160
+
+[[inventory.stock]]
+obj = "obj.steel_platebody"
+count = 5
+restockCycles = 320
+
+[[inventory.stock]]
+obj = "obj.mithril_platebody"
+count = 4
+restockCycles = -1
+
+[[inventory.stock]]
+obj = "obj.adamant_platebody"
+count = 3
+restockCycles = -1
+

--- a/.data/raw-cache/server/shops/sebamo_staff_store.toml
+++ b/.data/raw-cache/server/shops/sebamo_staff_store.toml
@@ -1,0 +1,50 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.sebamo_staff_store"
+name = "Sebamo's Sublime Staffs"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 550
+delta = 20
+
+size = 6
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.plainstaff"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.magic_staff"
+count = 5
+restockCycles = 200
+
+[[inventory.stock]]
+obj = "obj.staff_of_air"
+count = 2
+restockCycles = 1000
+
+[[inventory.stock]]
+obj = "obj.staff_of_water"
+count = 2
+restockCycles = 1000
+
+[[inventory.stock]]
+obj = "obj.staff_of_earth"
+count = 2
+restockCycles = 1000
+
+[[inventory.stock]]
+obj = "obj.staff_of_fire"
+count = 2
+restockCycles = 1000
+

--- a/.data/raw-cache/server/shops/shayzien_clothesshop.toml
+++ b/.data/raw-cache/server/shops/shayzien_clothesshop.toml
@@ -1,0 +1,80 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.shayzien_clothesshop"
+name = "Shayzien Styles"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 550
+delta = 10
+
+size = 12
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.white_apron"
+count = 3
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.leather_armour"
+count = 12
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.leather_gloves"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.leather_boots"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.brown_apron"
+count = 1
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.black_skirt"
+count = 3
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.blue_skirt"
+count = 2
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.red_cape"
+count = 4
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.black_cape"
+count = 4
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.blue_cape"
+count = 4
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.yellow_cape"
+count = 4
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.chefs_hat"
+count = 4
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/shayzien_pub.toml
+++ b/.data/raw-cache/server/shops/shayzien_pub.toml
@@ -1,0 +1,45 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.shayzien_pub"
+name = "The Cloak and Stagger"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 550
+delta = 20
+
+size = 5
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.beer"
+count = 10
+restockCycles = 50
+
+[[inventory.stock]]
+obj = "obj.shayzien_lizardkicker"
+count = 10
+restockCycles = 50
+
+[[inventory.stock]]
+obj = "obj.jug_wine"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.cup_of_tea"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.stew"
+count = 5
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/shayzien_rangeshop.toml
+++ b/.data/raw-cache/server/shops/shayzien_rangeshop.toml
@@ -1,0 +1,105 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.shayzien_rangeshop"
+name = "Daryl's Ranging Surplus"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 550
+delta = 10
+
+size = 17
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.shortbow"
+count = 4
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.longbow"
+count = 4
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.oak_shortbow"
+count = 3
+restockCycles = 200
+
+[[inventory.stock]]
+obj = "obj.oak_longbow"
+count = 3
+restockCycles = 200
+
+[[inventory.stock]]
+obj = "obj.willow_shortbow"
+count = 2
+restockCycles = 200
+
+[[inventory.stock]]
+obj = "obj.willow_longbow"
+count = 2
+restockCycles = 200
+
+[[inventory.stock]]
+obj = "obj.maple_shortbow"
+count = 1
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.maple_longbow"
+count = 1
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.crossbow"
+count = 2
+restockCycles = 400
+
+[[inventory.stock]]
+obj = "obj.bronze_arrow"
+count = 2000
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.iron_arrow"
+count = 1500
+restockCycles = 15
+
+[[inventory.stock]]
+obj = "obj.steel_arrow"
+count = 1000
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.mithril_arrow"
+count = 800
+restockCycles = 15
+
+[[inventory.stock]]
+obj = "obj.adamant_arrow"
+count = 600
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.rune_arrow"
+count = 200
+restockCycles = 30
+
+[[inventory.stock]]
+obj = "obj.bolt"
+count = 2000
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.xbows_crossbow_bolts_iron"
+count = 1500
+restockCycles = 15
+

--- a/.data/raw-cache/server/shops/shipyard_shop.toml
+++ b/.data/raw-cache/server/shops/shipyard_shop.toml
@@ -1,0 +1,45 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.shipyard_shop"
+name = "Seb's Shipyard Supplies"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1300
+buyMultiplier = 500
+delta = 0
+
+size = 5
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.nails_bronze"
+count = 1000
+restockCycles = 1
+
+[[inventory.stock]]
+obj = "obj.nails_iron"
+count = 1000
+restockCycles = 1
+
+[[inventory.stock]]
+obj = "obj.swamppaste"
+count = 2500
+restockCycles = 1
+
+[[inventory.stock]]
+obj = "obj.boat_repair_kit"
+count = 500
+restockCycles = 1
+
+[[inventory.stock]]
+obj = "obj.sailing_facility_bottle_empty"
+count = 100
+restockCycles = 1
+

--- a/.data/raw-cache/server/shops/stonecutter_stonemason.toml
+++ b/.data/raw-cache/server/shops/stonecutter_stonemason.toml
@@ -1,0 +1,50 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.stonecutter_stonemason"
+name = "Stonecutter Supplies"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1300
+buyMultiplier = 500
+delta = 30
+
+size = 6
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.bronze_pickaxe"
+count = 5
+restockCycles = 50
+
+[[inventory.stock]]
+obj = "obj.limestonebrick"
+count = 100
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.marble_block"
+count = 30
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.gold_leaf"
+count = 40
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.poh_magic_crystal"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.poh_condensed_gold"
+count = 10
+restockCycles = -1
+

--- a/.data/raw-cache/server/shops/sunset_coast_fishing_shop.toml
+++ b/.data/raw-cache/server/shops/sunset_coast_fishing_shop.toml
@@ -1,0 +1,110 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.sunset_coast_fishing_shop"
+name = "Picaria's Fishing Shop"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 700
+delta = 10
+
+size = 18
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.net"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.big_net"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.fishing_rod"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.fly_fishing_rod"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.harpoon"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.lobster_pot"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.fishing_bait"
+count = 1000
+restockCycles = 1
+
+[[inventory.stock]]
+obj = "obj.pack_fishing_bait"
+count = 100
+restockCycles = 5
+
+[[inventory.stock]]
+obj = "obj.feather"
+count = 1000
+restockCycles = 1
+
+[[inventory.stock]]
+obj = "obj.pack_feather"
+count = 100
+restockCycles = 5
+
+[[inventory.stock]]
+obj = "obj.raw_sardine"
+count = 10
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_herring"
+count = 10
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_mackerel"
+count = 10
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_cod"
+count = 10
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_tuna"
+count = 10
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_bass"
+count = 6
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_swordfish"
+count = 4
+restockCycles = 150
+
+[[inventory.stock]]
+obj = "obj.raw_lobster"
+count = 4
+restockCycles = 150
+

--- a/.data/raw-cache/server/shops/sunset_coast_helmet_shop.toml
+++ b/.data/raw-cache/server/shops/sunset_coast_helmet_shop.toml
@@ -1,0 +1,70 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.sunset_coast_helmet_shop"
+name = "Thurid's Brain Buckets"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1300
+buyMultiplier = 400
+delta = 30
+
+size = 10
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.bronze_med_helm"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.iron_med_helm"
+count = 4
+restockCycles = 200
+
+[[inventory.stock]]
+obj = "obj.steel_med_helm"
+count = 4
+restockCycles = 400
+
+[[inventory.stock]]
+obj = "obj.mithril_med_helm"
+count = 3
+restockCycles = 3000
+
+[[inventory.stock]]
+obj = "obj.adamant_med_helm"
+count = 2
+restockCycles = 12000
+
+[[inventory.stock]]
+obj = "obj.bronze_full_helm"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.iron_full_helm"
+count = 4
+restockCycles = 200
+
+[[inventory.stock]]
+obj = "obj.steel_full_helm"
+count = 4
+restockCycles = 400
+
+[[inventory.stock]]
+obj = "obj.mithril_full_helm"
+count = 3
+restockCycles = 3000
+
+[[inventory.stock]]
+obj = "obj.adamant_full_helm"
+count = 2
+restockCycles = 12000
+

--- a/.data/raw-cache/server/shops/tal_teklan_archershop.toml
+++ b/.data/raw-cache/server/shops/tal_teklan_archershop.toml
@@ -1,0 +1,90 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.tal_teklan_archershop"
+name = "Arcuani's Archery Supplies"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 550
+delta = 10
+
+size = 14
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.shortbow"
+count = 4
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.longbow"
+count = 4
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.oak_shortbow"
+count = 3
+restockCycles = 200
+
+[[inventory.stock]]
+obj = "obj.oak_longbow"
+count = 3
+restockCycles = 200
+
+[[inventory.stock]]
+obj = "obj.willow_shortbow"
+count = 2
+restockCycles = 200
+
+[[inventory.stock]]
+obj = "obj.willow_longbow"
+count = 2
+restockCycles = 200
+
+[[inventory.stock]]
+obj = "obj.maple_shortbow"
+count = 1
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.maple_longbow"
+count = 1
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.bronze_arrow"
+count = 2000
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.iron_arrow"
+count = 1500
+restockCycles = 15
+
+[[inventory.stock]]
+obj = "obj.steel_arrow"
+count = 1000
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.mithril_arrow"
+count = 800
+restockCycles = 15
+
+[[inventory.stock]]
+obj = "obj.adamant_arrow"
+count = 600
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.rune_arrow"
+count = 200
+restockCycles = 30
+

--- a/.data/raw-cache/server/shops/tal_teklan_dyeshop.toml
+++ b/.data/raw-cache/server/shops/tal_teklan_dyeshop.toml
@@ -1,0 +1,50 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.tal_teklan_dyeshop"
+name = "Dyes to Die For"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1300
+buyMultiplier = 550
+delta = 10
+
+size = 6
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.reddye"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.yellowdye"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.bluedye"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.orangedye"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.greendye"
+count = 10
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.purpledye"
+count = 10
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/tal_teklan_generalstore.toml
+++ b/.data/raw-cache/server/shops/tal_teklan_generalstore.toml
@@ -1,0 +1,100 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.tal_teklan_generalstore"
+name = "Tal Teklan General Store"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1300
+buyMultiplier = 400
+delta = 30
+
+size = 16
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.bronze_pickaxe"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.bronze_axe"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.chisel"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.spade"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.hammer"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.knife"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.tinderbox"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.pestle_and_mortar"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.needle"
+count = 5
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.thread"
+count = 30
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.rope"
+count = 10
+restockCycles = 30
+
+[[inventory.stock]]
+obj = "obj.pot_empty"
+count = 15
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.jug_empty"
+count = 15
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.bucket_empty"
+count = 15
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.bowl_empty"
+count = 15
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.vial_empty"
+count = 15
+restockCycles = 150
+

--- a/.data/raw-cache/server/shops/tal_teklan_runeshop.toml
+++ b/.data/raw-cache/server/shops/tal_teklan_runeshop.toml
@@ -1,0 +1,100 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.tal_teklan_runeshop"
+name = "Tal Teklan Rune Shop"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1000
+buyMultiplier = 550
+delta = 1
+
+size = 16
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.airrune"
+count = 5000
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.waterrune"
+count = 5000
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.earthrune"
+count = 5000
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.firerune"
+count = 5000
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.mindrune"
+count = 3000
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.bodyrune"
+count = 3000
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.chaosrune"
+count = 250
+restockCycles = 15
+
+[[inventory.stock]]
+obj = "obj.deathrune"
+count = 100
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.cosmicrune"
+count = 30
+restockCycles = 75
+
+[[inventory.stock]]
+obj = "obj.naturerune"
+count = 30
+restockCycles = 20
+
+[[inventory.stock]]
+obj = "obj.pack_airrune"
+count = 100
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.pack_waterrune"
+count = 100
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.pack_earthrune"
+count = 100
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.pack_firerune"
+count = 100
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.pack_mindrune"
+count = 50
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.pack_chaosrune"
+count = 30
+restockCycles = 10
+

--- a/.data/raw-cache/server/shops/tzhaar_shop_cityequipment.toml
+++ b/.data/raw-cache/server/shops/tzhaar_shop_cityequipment.toml
@@ -1,0 +1,75 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.tzhaar_shop_cityequipment"
+name = "TzHaar-Hur-Zal's Equipment Store"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1500
+buyMultiplier = 150
+delta = 20
+
+size = 11
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.tzhaar_throwingring"
+count = 500
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.tzhaar_splitsword"
+count = 1
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.tzhaar_knife"
+count = 1
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.tzhaar_maul"
+count = 1
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.tzhaar_staff"
+count = 1
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.tzhaar_mace"
+count = 1
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.tzhaar_cape_obsidian"
+count = 1
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.tzhaar_spikeshield"
+count = 1
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.obsidian_helmet"
+count = 1
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.obsidian_platebody"
+count = 1
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.obsidian_platelegs"
+count = 1
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/tzhaar_shop_cityoreandgem.toml
+++ b/.data/raw-cache/server/shops/tzhaar_shop_cityoreandgem.toml
@@ -1,0 +1,100 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.tzhaar_shop_cityoreandgem"
+name = "TzHaar-Hur-Rin's Ore and Gem Store"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1500
+buyMultiplier = 150
+delta = 20
+
+size = 16
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.tin_ore"
+count = 25
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.copper_ore"
+count = 25
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.iron_ore"
+count = 15
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.silver_ore"
+count = 12
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.coal"
+count = 20
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.gold_ore"
+count = 12
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.mithril_ore"
+count = 4
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.adamantite_ore"
+count = 2
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.runite_ore"
+count = 1
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.uncut_sapphire"
+count = 16
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.uncut_emerald"
+count = 12
+restockCycles = 300
+
+[[inventory.stock]]
+obj = "obj.uncut_ruby"
+count = 8
+restockCycles = 500
+
+[[inventory.stock]]
+obj = "obj.uncut_diamond"
+count = 6
+restockCycles = 1000
+
+[[inventory.stock]]
+obj = "obj.uncut_dragonstone"
+count = 0
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.uncut_onyx"
+count = 1
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.xbows_bolt_tips_onyx"
+count = 50
+restockCycles = 100
+

--- a/.data/raw-cache/server/shops/viking_fishmonger.toml
+++ b/.data/raw-cache/server/shops/viking_fishmonger.toml
@@ -1,0 +1,140 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.viking_fishmonger"
+name = "Fremennik Fish Monger"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1300
+buyMultiplier = 700
+delta = 30
+
+size = 24
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.net"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.fishing_rod"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.fly_fishing_rod"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.harpoon"
+count = 2
+restockCycles = 400
+
+[[inventory.stock]]
+obj = "obj.lobster_pot"
+count = 2
+restockCycles = 400
+
+[[inventory.stock]]
+obj = "obj.fishing_bait"
+count = 1500
+restockCycles = 1
+
+[[inventory.stock]]
+obj = "obj.pack_fishing_bait"
+count = 80
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.feather"
+count = 1000
+restockCycles = 1
+
+[[inventory.stock]]
+obj = "obj.pack_feather"
+count = 50
+restockCycles = 2
+
+[[inventory.stock]]
+obj = "obj.big_net"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.raw_shrimp"
+count = 0
+restockCycles = 300
+
+[[inventory.stock]]
+obj = "obj.raw_sardine"
+count = 200
+restockCycles = 1
+
+[[inventory.stock]]
+obj = "obj.raw_herring"
+count = 0
+restockCycles = 900
+
+[[inventory.stock]]
+obj = "obj.raw_mackerel"
+count = 0
+restockCycles = 1000
+
+[[inventory.stock]]
+obj = "obj.raw_cod"
+count = 0
+restockCycles = 1100
+
+[[inventory.stock]]
+obj = "obj.raw_anchovies"
+count = 0
+restockCycles = 1200
+
+[[inventory.stock]]
+obj = "obj.raw_trout"
+count = 0
+restockCycles = 1500
+
+[[inventory.stock]]
+obj = "obj.raw_pike"
+count = 0
+restockCycles = 1800
+
+[[inventory.stock]]
+obj = "obj.raw_salmon"
+count = 0
+restockCycles = 2100
+
+[[inventory.stock]]
+obj = "obj.raw_tuna"
+count = 0
+restockCycles = 2300
+
+[[inventory.stock]]
+obj = "obj.raw_lobster"
+count = 0
+restockCycles = 2600
+
+[[inventory.stock]]
+obj = "obj.raw_bass"
+count = 0
+restockCycles = 2700
+
+[[inventory.stock]]
+obj = "obj.raw_swordfish"
+count = 0
+restockCycles = 2900
+
+[[inventory.stock]]
+obj = "obj.raw_shark"
+count = 0
+restockCycles = 3500
+

--- a/.data/raw-cache/server/shops/warrens_fishmonger.toml
+++ b/.data/raw-cache/server/shops/warrens_fishmonger.toml
@@ -1,0 +1,140 @@
+[[inventory]]
+isServerOnly = true
+id = "inv.warrens_fishmonger"
+name = "Warrens Fish Monger"
+
+scope = "Shared"
+stack = "Always"
+
+sellMultiplier = 1300
+buyMultiplier = 700
+delta = 30
+
+size = 24
+
+protect = false
+runWeight = false
+restock = true
+allStock = false
+placeholders = false
+
+[[inventory.stock]]
+obj = "obj.net"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.fishing_rod"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.fly_fishing_rod"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.harpoon"
+count = 2
+restockCycles = 400
+
+[[inventory.stock]]
+obj = "obj.lobster_pot"
+count = 2
+restockCycles = 400
+
+[[inventory.stock]]
+obj = "obj.fishing_bait"
+count = 1500
+restockCycles = 1
+
+[[inventory.stock]]
+obj = "obj.pack_fishing_bait"
+count = 80
+restockCycles = 10
+
+[[inventory.stock]]
+obj = "obj.feather"
+count = 1000
+restockCycles = 1
+
+[[inventory.stock]]
+obj = "obj.pack_feather"
+count = 50
+restockCycles = 2
+
+[[inventory.stock]]
+obj = "obj.big_net"
+count = 5
+restockCycles = 100
+
+[[inventory.stock]]
+obj = "obj.raw_shrimp"
+count = 0
+restockCycles = 300
+
+[[inventory.stock]]
+obj = "obj.raw_sardine"
+count = 200
+restockCycles = 1
+
+[[inventory.stock]]
+obj = "obj.raw_herring"
+count = 0
+restockCycles = 900
+
+[[inventory.stock]]
+obj = "obj.raw_mackerel"
+count = 0
+restockCycles = 1000
+
+[[inventory.stock]]
+obj = "obj.raw_cod"
+count = 0
+restockCycles = 1100
+
+[[inventory.stock]]
+obj = "obj.raw_anchovies"
+count = 0
+restockCycles = 1200
+
+[[inventory.stock]]
+obj = "obj.raw_trout"
+count = 0
+restockCycles = 1500
+
+[[inventory.stock]]
+obj = "obj.raw_pike"
+count = 0
+restockCycles = 1800
+
+[[inventory.stock]]
+obj = "obj.raw_salmon"
+count = 0
+restockCycles = 2100
+
+[[inventory.stock]]
+obj = "obj.raw_tuna"
+count = 0
+restockCycles = 2300
+
+[[inventory.stock]]
+obj = "obj.raw_lobster"
+count = 0
+restockCycles = 2600
+
+[[inventory.stock]]
+obj = "obj.raw_bass"
+count = 0
+restockCycles = 2700
+
+[[inventory.stock]]
+obj = "obj.raw_swordfish"
+count = 0
+restockCycles = 2900
+
+[[inventory.stock]]
+obj = "obj.raw_shark"
+count = 0
+restockCycles = 3500
+


### PR DESCRIPTION
Stock TOML for the 94 shops mapped in #162, generated with the bucket source from #163 — 94 of 94 dumped, no unresolved items, and `./gradlew run` boots clean with them packed. Re-running `dumpShops --source=bucket` reproduces the files byte-for-byte, and a sample was opened in-client after a cache rebuild to confirm the rendered stock matches the wiki.
