### PR TITLE
fix: opt drop-table out of Gradle 9 failOnNoDiscoveredTests

### DIFF
--- a/api/drop-table/build.gradle.kts
+++ b/api/drop-table/build.gradle.kts
@@ -5,3 +5,7 @@ plugins {
 dependencies {
     implementation(libs.kotlin.reflect)
 }
+
+// src/test holds vendored drop-table DSL examples with no @Test methods;
+// Gradle 9 fails test tasks that discover no tests unless opted out.
+tasks.test { failOnNoDiscoveredTests = false }


### PR DESCRIPTION
`./gradlew test` fails on a clean checkout: api/drop-table's test source set holds vendored DSL example files with no @Test methods, and Gradle 9's failOnNoDiscoveredTests default treats an empty test task as an error. This opts the module out so the standard test task can run.
