### PR TITLE
ci: optional formatting check scoped to changed files

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,41 @@
+name: Formatting
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: format-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  spotless:
+    name: spotless (advisory)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      # Spotless is configured with ratchetFrom("origin/main"), so only files
+      # changed relative to main are checked. The ref must exist locally.
+      - name: Check formatting
+        run: |
+          git fetch origin main --depth=1
+          ./gradlew spotlessCheck

--- a/build-logic/src/main/kotlin/formatter-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/formatter-conventions.gradle.kts
@@ -3,6 +3,12 @@ plugins {
 }
 
 spotless {
+    // Only enforce formatting on files changed relative to main. The codebase
+    // predates enforcement and has drifted (~1,030 files as of revision 240),
+    // so a repo-wide check would fail every build; ratcheting stops new drift
+    // without a disruptive one-time reformat.
+    ratchetFrom("origin/main")
+
     kotlin {
         ktfmt().kotlinlangStyle().configure {
             it.setMaxWidth(100)


### PR DESCRIPTION
Entirely optional companion to #169 — close this one without a second thought if you'd rather not have formatting in CI.

It runs spotlessCheck as its own separate advisory check. The ratchetFrom("origin/main") addition means only files a PR actually changes get checked, so the existing repo-wide formatting drift stays untouched and unenforced — nobody is asked to reformat anything they didn't touch.
