### PR TITLE
fix: keep the killcount overlay visible inside god wars boss instances

### DIFF
--- a/content/areas/godwars/build.gradle.kts
+++ b/content/areas/godwars/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
     implementation(projects.api.areaChecker)
+    implementation(projects.api.instances)
     implementation(projects.api.pluginCommons)
     implementation(projects.engine.utilsBits)
 }

--- a/content/areas/godwars/src/main/kotlin/org/rsmod/content/areas/godwars/GodwarsOverlayScript.kt
+++ b/content/areas/godwars/src/main/kotlin/org/rsmod/content/areas/godwars/GodwarsOverlayScript.kt
@@ -1,26 +1,69 @@
 package org.rsmod.content.areas.godwars
 
 import jakarta.inject.Inject
+import org.rsmod.api.instances.InstanceManager
+import org.rsmod.api.instances.events.InstancePlayerJoinUnboundEvent
+import org.rsmod.api.instances.events.InstancePlayerLeaveUnboundEvent
 import org.rsmod.api.player.ui.ifCloseOverlay
 import org.rsmod.api.player.ui.ifOpenOverlay
+import org.rsmod.api.player.vars.boolVarBit
 import org.rsmod.api.script.onArea
 import org.rsmod.api.script.onAreaExit
+import org.rsmod.api.script.onEvent
+import org.rsmod.api.table.InstanceSettingsRow
 import org.rsmod.events.EventBus
+import org.rsmod.game.entity.Player
 import org.rsmod.plugin.scripts.PluginScript
 import org.rsmod.plugin.scripts.ScriptContext
 
-class GodwarsOverlayScript @Inject constructor(private val eventBus: EventBus) : PluginScript() {
+class GodwarsOverlayScript
+@Inject
+constructor(private val eventBus: EventBus, private val instances: InstanceManager) :
+    PluginScript() {
+    /**
+     * The overlay's client script hides the killcount layer unless the player stands in the
+     * dungeon's map squares. Boss rooms are on dynamic map, so this flag stands in for that check.
+     */
+    private var Player.inBossInstance by boolVarBit("varbit.godwars_instance")
+
     override fun ScriptContext.startup() {
+        val bossKeys =
+            BOSS_INSTANCE_ROWS.mapTo(mutableSetOf()) { InstanceSettingsRow.getRow(it).key }
+
         onArea("area.godwars_dungeon") {
             player.ifOpenOverlay(
                 "interface.godwars_overlay",
                 "component.toplevel_osrs_stretch:overlay_hud",
-                eventBus
+                eventBus,
             )
+            val sessionKey = instances.sessionForPlayer(player)?.key
+            player.inBossInstance = sessionKey != null && sessionKey in bossKeys
         }
+
         onAreaExit("area.godwars_dungeon") {
             player.ifCloseOverlay("interface.godwars_overlay", eventBus)
         }
+
+        onEvent<InstancePlayerJoinUnboundEvent> {
+            if (key in bossKeys) {
+                player.inBossInstance = true
+            }
+        }
+
+        onEvent<InstancePlayerLeaveUnboundEvent> {
+            if (key in bossKeys) {
+                player.inBossInstance = false
+            }
+        }
     }
 
+    private companion object {
+        val BOSS_INSTANCE_ROWS =
+            listOf(
+                "dbrow.instance_graardor",
+                "dbrow.instance_kreearra",
+                "dbrow.instance_zilyana",
+                "dbrow.instance_kril",
+            )
+    }
 }


### PR DESCRIPTION
The killcount overlay vanishes inside the god wars boss rooms (#149). Its client script only draws that layer when the player stands in the dungeon's map squares or when varbit godwars_instance is set, and boss rooms are copied onto dynamic map, so the coordinate test fails and the layer hides even though the server still has the interface open. Nothing in the repo set that varbit.

This sets it from instance membership on join and leave, and reasserts it on entering the dungeon so a stale value from an earlier visit is corrected. The public rooms are copied regions too, so both entry paths were affected.

Checked in a live client: entering Graardor's room previously blanked the overlay and now keeps it, showing the killcount already decremented by the 40 spent on entry; leaving clears the varbit.

The issue blames area checks not normalising coordinates in dynamic regions, but normalizedCoords() and AreaChecker.inArea already normalise and the interface does stay open inside, so nothing there needed changing.
