### PR TITLE
ci: build the fixed head after a gameval auto-fix

### DIFF
--- a/.github/workflows/gameval-conflicts.yml
+++ b/.github/workflows/gameval-conflicts.yml
@@ -13,6 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  actions: write
   contents: write
   checks: write
   pull-requests: write
@@ -113,3 +114,9 @@ jobs:
           } > /tmp/gameval-pr-body.md
 
           gh pr comment "${{ github.event.pull_request.number }}" --body-file /tmp/gameval-pr-body.md
+
+          # Runs from that push are held for approval, so nothing builds the
+          # reassigned IDs; workflow_dispatch is not held. It 422s on branches
+          # that predate ci.yml, which must not fail an otherwise good fix.
+          gh workflow run ci.yml --ref "${{ github.head_ref }}" ||
+            echo "::warning::could not dispatch ci.yml for the fixed head"


### PR DESCRIPTION
When the gameval check auto-fixes a conflict it pushes with GITHUB_TOKEN, and the runs from that push are held for approval rather than started, so the fixed head never gets built. This adds `actions: write` and dispatches `ci.yml` after the fix push, since `workflow_dispatch` is not held. Tested on a fork with and without.

It does not sequence the two workflows, so the build still races the gameval check. Approving the held run too gives two builds of the same commit.
