### PR TITLE
fix: give each plugin pack module distinct gradle coordinates

### DIFF
--- a/or-cache/build.gradle.kts
+++ b/or-cache/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
 // cache data (db tables, configs, models, sprites) in a `<plugin>/pack` module so building the
 // cache never has to compile the plugin's game scripts or their api/content dependencies.
 fun findContentPlugins(): List<Project> =
-    project(":content").subprojects.filter { it.name == "pack" && it.buildFile.exists() }
+    project(":content").subprojects.filter { it.name.endsWith("-pack") && it.buildFile.exists() }
 
 tasks {
     register("buildCache",JavaExec::class) {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -61,5 +61,14 @@ fun searchProject(parentName: String, root: Path, currentPath: Path) {
         return
     }
     val projectName = relativePath.toString().replace(File.separator, ":")
-    include("$parentName:$projectName")
+    val projectPath = "$parentName:$projectName"
+    include(projectPath)
+
+    // Plugin packs all live in a directory named `pack`, so they would share `org.rsmod:pack`
+    // coordinates and Gradle would drop all but one by conflict resolution. Naming them after the
+    // plugin keeps the directory convention and makes the coordinates distinct.
+    val project = project(":$projectPath")
+    if (project.name == "pack") {
+        project.name = "${project.parent?.name}-pack"
+    }
 }


### PR DESCRIPTION
A second plugin pack module never reaches the cache build classpath. Every one of them is named `pack`, so they share `org.rsmod:pack` coordinates and Gradle drops all but one by conflict resolution; ClassGraph then never finds the loser's PluginPack and its tables and configs are skipped with nothing erroring. Naming the project after its plugin makes the coordinates distinct and keeps the `<plugin>/pack` directory layout.
