### PR TITLE
Fix osrs-mcp SERVER cache search: register custom CacheVarLiterals before decoding

### DIFF
--- a/tools/osrs-mcp/src/main/kotlin/org/rsmod/tools/mcp/wiki/CacheTool.kt
+++ b/tools/osrs-mcp/src/main/kotlin/org/rsmod/tools/mcp/wiki/CacheTool.kt
@@ -3,11 +3,18 @@ package org.rsmod.tools.mcp.wiki
 import dev.openrune.OsrsCacheProvider
 import dev.openrune.definition.type.ItemType
 import dev.openrune.definition.type.NpcType
+import dev.openrune.definition.util.CacheVarLiteral
 import dev.openrune.filesystem.Cache
 import java.lang.reflect.Modifier
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.ConcurrentHashMap
+
+private val registerCustomVarLiterals: Unit by lazy {
+    CacheVarLiteral.registerExternal(253, '[', name = "PROJANIM")
+    CacheVarLiteral.registerExternal(254, ']', name = "VARBIT")
+    Unit
+}
 
 enum class CacheKind {
     LIVE,
@@ -129,6 +136,7 @@ class CacheTool {
     }
 
     private fun buildSnapshot(cacheKind: CacheKind, root: Path, revision: Int): Snapshot {
+        registerCustomVarLiterals
         val cachePath = root.resolve(".data").resolve("cache").resolve(cacheKind.name)
         require(Files.isDirectory(cachePath)) { "Unable to find cache directory at: $cachePath" }
 


### PR DESCRIPTION
## Bug
Any \`cache_search\` call against \`cache=SERVER\` in \`tools/osrs-mcp\` fails immediately, regardless of type/id/query:

```
IllegalStateException: Error finding CacheVarLiteral: ]
  at dev.openrune.definition.util.CacheVarLiteral$Companion.getChar(CacheVarLiteral.kt:29)
  at dev.openrune.definition.codec.EnumCodec.read(EnumCodec.kt:14)
```

## Root cause
\`or-cache/src/main/kotlin/dev/openrune/CacheTools.kt\` registers two custom \`CacheVarLiteral\` extensions before touching the cache:
```kotlin
CacheVarLiteral.registerExternal(253, '[', name = "PROJANIM")
CacheVarLiteral.registerExternal(254, ']', name = "VARBIT")
```
\`tools/osrs-mcp\`'s \`CacheTool.kt\` never did the same. Any enum whose value type is VARBIT (e.g. Slayer's \`slayer_toggleable_rewards\`, \`enum<DBRowType, VarBitType>\`) throws while decoding, which aborts the *entire* SERVER-cache snapshot build in one shot - so every subsequent query fails identically, making it look like a total cache-load failure rather than one bad record.

Confirmed this isn't an OpenRune-FileStore bug by reproducing the same trace with a standalone \`OsrsCacheProvider\` call, completely outside osrs-mcp.

## Fix
Register the same two \`CacheVarLiteral\` extensions in \`CacheTool.kt\` before building a snapshot, mirroring what \`or-cache/CacheTools.kt\` already does.

## Testing
Compiled clean. Confirmed \`cache_search(cache=SERVER, ...)\` works correctly after the fix (previously failed on every query; now returns real results, e.g. NPC/item lookups by id and by name).