### PR TITLE
Fix server crash on ranged weapons missing proj_launch param

### DIFF
--- a/api/combat/combat-scripts/src/main/kotlin/org/rsmod/api/combat/PvNCombat.kt
+++ b/api/combat/combat-scripts/src/main/kotlin/org/rsmod/api/combat/PvNCombat.kt
@@ -202,12 +202,8 @@ constructor(
         // has no `proj_launch` param, a "null" (-1) spotanim will still be sent in the same slot
         // and height as usual.
         val launchSpotanim = weaponType.paramOrNull(params.proj_launch)?.id ?: NULL_SPOTANIM_ID
-        val launchSpotanimName =
-            if (launchSpotanim == NULL_SPOTANIM_ID) {
-                null
-            } else {
-                RSCM.getReverseMapping(RSCMType.SPOTANIM, launchSpotanim)
-            }
+    
+        val launchSpotanimName = launchSpotanim.takeUnless { it == NULL_SPOTANIM_ID } ?.let { RSCM.getReverseMapping(RSCMType.SPOTANIM, it) }
         spotanim(launchSpotanimName, height = 96, slot = constants.spotanim_slot_combat)
 
         val projanim = manager.spawnProjectile(player, npc, travelSpotanim, projanimType)

--- a/api/combat/combat-scripts/src/main/kotlin/org/rsmod/api/combat/PvNCombat.kt
+++ b/api/combat/combat-scripts/src/main/kotlin/org/rsmod/api/combat/PvNCombat.kt
@@ -202,7 +202,13 @@ constructor(
         // has no `proj_launch` param, a "null" (-1) spotanim will still be sent in the same slot
         // and height as usual.
         val launchSpotanim = weaponType.paramOrNull(params.proj_launch)?.id ?: NULL_SPOTANIM_ID
-        player.spotanim(RSCM.getReverseMapping(RSCMType.SPOTANIM,launchSpotanim), height = 96, slot = constants.spotanim_slot_combat)
+        val launchSpotanimName =
+            if (launchSpotanim == NULL_SPOTANIM_ID) {
+                null
+            } else {
+                RSCM.getReverseMapping(RSCMType.SPOTANIM, launchSpotanim)
+            }
+        spotanim(launchSpotanimName, height = 96, slot = constants.spotanim_slot_combat)
 
         val projanim = manager.spawnProjectile(player, npc, travelSpotanim, projanimType)
         val (serverDelay, clientDelay) = projanim.durations


### PR DESCRIPTION
## Bug
Attacking with any ranged weapon whose quiver/righthand type has no `proj_launch` param (e.g. Light ballista) crashes the player's main game cycle on every single attack:

```
[ERROR] - Error processing main cycle for player: Player(username=...)
java.lang.IllegalStateException: Missing mapping '65535' in table 'spotanim'
  at dev.openrune.definition.constants.ConstantProvider.getReverseMapping(ConstantProvider.kt:119)
  at dev.openrune.rscm.RSCM.getReverseMapping(RSCM.kt:89)
  at org.rsmod.api.combat.PvNCombat.attackRanged(PvNCombat.kt:205)
```

## Root cause
`PvNCombat.kt:201-205`:
```kotlin
// Official behavior: If the weapon (quiver or righthand, based on the thrown weapon flag)
// has no `proj_launch` param, a "null" (-1) spotanim will still be sent in the same slot
// and height as usual.
val launchSpotanim = weaponType.paramOrNull(params.proj_launch)?.id ?: NULL_SPOTANIM_ID
player.spotanim(RSCM.getReverseMapping(RSCMType.SPOTANIM,launchSpotanim), height = 96, slot = constants.spotanim_slot_combat)
```
`NULL_SPOTANIM_ID` is `0xFFFF` (`CombatCommons.kt:7`) - a sentinel meaning "no spotanim," not a real cache id. The code runs it through `RSCM.getReverseMapping` unconditionally, but there's obviously no RSCM name registered for "no spotanim," so this throws every time.

## Fix
`ProtectedAccess.spotanim(spot: String?, ...)` already handles exactly this case - passing `null` calls `resetSpotanim()` instead of trying to resolve a name, matching the comment's own stated intent ("a null (-1) spotanim will still be sent"). This skips the reverse-mapping lookup only when the value is the null sentinel, leaving the real-spotanim path untouched.

## Testing
Compiled clean. Confirmed in-client: Light ballista (missing `proj_launch`) crashed the server on every attack before this fix, and now fires normally (both regular attacks and its special) with no crash. Also spot-checked Zaryte crossbow (has `proj_launch` set) to confirm the normal-spotanim path is unaffected.