### PR TITLE
Fix: Removing the loc anim for pottery wheel (it shouldn't have any).

### DIFF
--- a/content/skills/crafting/src/main/kotlin/org/rsmod/content/skills/crafting/CraftingSection.kt
+++ b/content/skills/crafting/src/main/kotlin/org/rsmod/content/skills/crafting/CraftingSection.kt
@@ -75,7 +75,6 @@ enum class CraftingSection(
         actionType = SkillingActionType.MAKE,
         ticks = 3,
         anim = CraftingConstants.ANIM_POTTERY_WHEEL,
-        locAnim = CraftingConstants.LOC_ANIM_POTTERY_WHEEL,
         sound = CraftingConstants.SOUND_POTTERY_WHEEL,
         repeatsSoundPerCraft = true,
         actionName = { "make ${it.output}" },

--- a/content/skills/crafting/src/main/kotlin/org/rsmod/content/skills/crafting/util/CraftingConstants.kt
+++ b/content/skills/crafting/src/main/kotlin/org/rsmod/content/skills/crafting/util/CraftingConstants.kt
@@ -59,7 +59,6 @@ object CraftingConstants {
     const val SOUND_WEAVING = "synth.loom_weave"
 
     const val ANIM_POTTERY_WHEEL = "seq.human_potterywheel"
-    const val LOC_ANIM_POTTERY_WHEEL = "loc.potterywheel"
     const val SOUND_POTTERY_WHEEL = "synth.crafting_pottery_wheel_craft"
     const val ANIM_POTTERY_OVEN = "seq.potteryoven_quick"
 


### PR DESCRIPTION
Saw 426ad9c6a233bf2871d03f3659277860f650e540 , the fix for the gem cutting default was correct. But I also made a mistake by having a nonexistent loc anim on the pottery wheel. The pottery wheel doesn't have a loc animation when crafting with it, soooo this PR removes that entirely.

I must have missed retesting the pottery wheel once I got rid of the invalid gameval checker for crafting. Sorry about that.